### PR TITLE
Add disable flag for emails

### DIFF
--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -112,13 +112,16 @@
                         (-> build :build :job-name-extra)))))
 
 (s/defn send? :- s/Bool
-  [build :- StoredBuild]
-  (pos?
-   (-> build :process :exit-code)))
+  [email-opts :- OptsEmail
+   build :- StoredBuild]
+  (and
+   (not (:disable email-opts))
+   (pos?
+    (-> build :process :exit-code))))
 
 (defn maybe-send! [opts {:keys [index type id] :as addr}]
   (let [build-doc (store/get (-> opts :es :conn) addr)
         failure-docs (store/get-failures opts (:id build-doc))]
-    (if (send? build-doc)
+    (if (send? (-> opts :email) build-doc)
       (send opts (make-context opts build-doc failure-docs))
       ((opts :logger) "NO MAIL GENERATED"))))

--- a/src/clj/runbld/opts.clj
+++ b/src/clj/runbld/opts.clj
@@ -53,7 +53,8 @@
     :template-txt "templates/email.mustache.txt"
     :template-html "templates/email.mustache.html"
     :text-only false
-    :max-failure-notify 10}
+    :max-failure-notify 10
+    :disable false}
 
    :slack
    {:success true

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -39,7 +39,8 @@
    :text-only          s/Bool
    :tls                s/Bool
    :to                 (s/cond-pre s/Str [s/Str])
-   :user               s/Str})
+   :user               s/Str
+   :disable            s/Bool})
 
 (def OptsSlack
   ;; hook is optional because the other values have defaults


### PR DESCRIPTION
@elasticdog You can set this in any profiles that don't need email notification:

```
  email:
    disable: true
```

It's live in `0.99.43`.