### PR TITLE
slack: remove parens arround job-name-extra

### DIFF
--- a/resources/templates/slack.mustache.json
+++ b/resources/templates/slack.mustache.json
@@ -3,6 +3,6 @@
     "attachments": [{
         "color": "{{color}}",
         "fallback": "{{process.status}} {{build.org-project-branch}} {{vcs.commit-short}} {{build.console-url}}",
-        "title": "{{process.status}} <{{vcs.branch-url}}|{{build.org-project-branch}}> <{{vcs.commit-url}}|{{vcs.commit-short}}> ({{build.job-name-extra}}) (<{{build.console-url}}|console log>)"
+        "title": "{{process.status}} <{{vcs.branch-url}}|{{build.org-project-branch}}> <{{vcs.commit-url}}|{{vcs.commit-short}}> {{build.job-name-extra}} (<{{build.console-url}}|console log>)"
     }]
 }


### PR DESCRIPTION
Fixes #39
Closes #40