### PR TITLE
Optionally send slack notifications when the build is fixed.

### DIFF
--- a/src/clj/runbld/opts.clj
+++ b/src/clj/runbld/opts.clj
@@ -57,7 +57,8 @@
     :disable false}
 
    :slack
-   {:success true
+   {:first-success true
+    :success true
     :failure true
     :template "templates/slack.mustache.json"
     :disable false}})

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -45,6 +45,7 @@
 (def OptsSlack
   ;; hook is optional because the other values have defaults
   {(s/optional-key :hook) (s/cond-pre s/Str [s/Str])
+   :first-success      s/Bool
    :success            s/Bool
    :failure            s/Bool
    :template           (s/cond-pre s/Str java.io.File)

--- a/test/config/slack.yml
+++ b/test/config/slack.yml
@@ -1,0 +1,21 @@
+es:
+  build-index: runbld-build
+  failure-index: runbld-failure
+  log-index: runbld-log
+
+slack:
+  success: false
+
+process:
+  env:
+    RUNBLD_TEST: RUNBLD_TEST
+
+email:
+  host: smtp.example.com
+  port: 587
+  user: smtpuser
+  pass: pass!
+  from: default@example.com
+  to: default@example.com
+  template-txt: test/templates/default.mustache
+  template-html: templates/email.mustache.html

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -1,16 +1,31 @@
 (ns runbld.test.main-test
   (:require [schema.test :as s])
   (:require [clojure.test :refer :all]
+            [clojure.walk :refer [keywordize-keys]]
             [runbld.build :as build]
             [runbld.notifications.email :as email]
+            [runbld.notifications.slack :as slack]
             [runbld.env :as env]
             [runbld.opts :as opts]
             [runbld.process :as proc]
             [runbld.store :as store]
             [runbld.io :as io]
             [runbld.vcs.git :as git]
-            [runbld.version :as version])
+            [runbld.version :as version]
+            [stencil.core :as mustache]
+            [cheshire.core :as json])
   (:require [runbld.main :as main] :reload-all))
+
+(def email (atom []))
+(def slack (atom []))
+
+(defn slack-msg []
+  (-> @slack
+      json/decode
+      keywordize-keys
+      :attachments
+      first
+      :title))
 
 (s/deftest main
   ;; Change root bindings for these Vars, affects any execution no
@@ -48,14 +63,23 @@
         (is (= String (type res)))
         (is (.startsWith res "#error {\n :cause boy that was "))))))
 
-(s/deftest execution
+(s/deftest execution-with-defaults
   (testing "real execution all the way through"
-    (let [email (atom [])]
-      (with-redefs [io/log (fn [& _] :noconsole)
-                    email/send* (fn [& args]
-                                  (swap! email concat args)
-                                  ;; to satisfy schema
-                                  {})]
+    (with-redefs [io/log (fn [& _] :noconsole)
+                  email/send* (fn [& args]
+                                (swap! email concat args)
+                                ;; to satisfy schema
+                                {})
+                  slack/send (fn [opts ctx]
+                               (let [f (-> opts :slack :template)
+                                     tmpl (-> f io/resolve-resource slurp)
+                                     color (if (-> ctx :process :failed)
+                                             "danger"
+                                             "good")
+                                     js (mustache/render-string
+                                         tmpl (assoc ctx :color color))]
+                                 (reset! slack js)))]
+      (testing "build failure -- default notification settings"
         (git/with-tmp-repo [d "tmp/git/main-test-2"]
           (let [args (conj
                       ["-c" "test/config/main.yml"
@@ -72,4 +96,82 @@
                          :process
                          :exit-code)))
             (is (.startsWith
-                 (let [[_ _ _ subj _ _] @email] subj) "FAILURE"))))))))
+                 (let [[_ _ _ subj _ _] @email] subj) "FAILURE"))
+            (is (.contains (slack-msg) "FAILURE")))))
+      (testing "build success: default notification settings"
+        (reset! email [])
+        (reset! slack [])
+        (git/with-tmp-repo [d "tmp/git/main-test-3"]
+          (let [args (conj
+                      ["-c" "test/config/main.yml"
+                       "-j" "elastic+foo+master"
+                       "-d" d]
+                      "test/success.bash")
+                opts (opts/parse-args args)
+                res (apply main/-main args)]
+            (is (= 0 (:exit-code res)))
+            (is (= 0 (-> (store/get (-> opts :es :conn)
+                                    (-> res :store-result :addr))
+                         :process
+                         :exit-code)))
+            (is (empty? @email))
+            (is (.contains (slack-msg) "SUCCESS"))))))))
+
+(s/deftest execution-with-slack-overrides
+  (testing "real execution all the way through"
+    (with-redefs [io/log (fn [& _] :noconsole)
+                  email/send* (fn [& args]
+                                (swap! email concat args)
+                                ;; to satisfy schema
+                                {})
+                  slack/send (fn [opts ctx]
+                               (let [f (-> opts :slack :template)
+                                     tmpl (-> f io/resolve-resource slurp)
+                                     color (if (-> ctx :process :failed)
+                                             "danger"
+                                             "good")
+                                     js (mustache/render-string
+                                         tmpl (assoc ctx :color color))]
+                                 (reset! slack js)))]
+      (testing "build success: notify on first success after failure(s)"
+        (reset! email [])
+        (reset! slack [])
+        ;; fail first
+        (git/with-tmp-repo [d "tmp/git/main-test-4"]
+          (let [args (conj
+                      ["-c" "test/config/slack.yml"
+                       "-j" "elastic+foo+master"
+                       "-d" d]
+                      "test/fail.bash")
+                opts (opts/parse-args args)
+                res (apply main/-main args)]))
+        ;; then succeed
+        (reset! email [])
+        (reset! slack [])
+        (git/with-tmp-repo [d "tmp/git/main-test-5"]
+          (let [args (conj
+                      ["-c" "test/config/slack.yml"
+                       "-j" "elastic+foo+master"
+                       "-d" d]
+                      "test/success.bash")
+                opts (merge (opts/parse-args args)
+                            {:slack
+                             {:success false}})
+                res (apply main/-main args)]
+            (is (empty? @email))
+            ;; we should get a slack notification
+            (is (.contains (slack-msg) "SUCCESS")))))
+      (testing "build success: don't notify on subsequent successes"
+        ;; succeed once more
+        (reset! email [])
+        (reset! slack [])
+        (git/with-tmp-repo [d "tmp/git/main-test-6"]
+          (let [args (conj
+                      ["-c" "test/config/slack.yml"
+                       "-j" "elastic+foo+master"
+                       "-d" d]
+                      "test/success.bash")
+                res (apply main/-main args)]
+            ;; we shouldn't get any more notifications
+            (is (empty? @email))
+            (is (empty? @slack))))))))


### PR DESCRIPTION
Adds a new configuration option, :first-success, that, when set to true, will determine whether the current successful build is the first success after a failure. If so, it will send a notification to the configured slack channel.

Adds tests for slack notifications to the exisitng tests of the main function.

Fixes #44.