### PR TITLE
Send plaintext email part in addition to HTML email

### DIFF
--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -69,11 +69,10 @@
    html     :- (s/maybe s/Str)
    attachments :- [s/Any]]
   (let [body (concat
-              [(if html
-                 {:type "text/html; charset=utf-8"
-                  :content html}
-                 {:type "text/plain; charset=utf-8"
-                  :content plain})]
+              [{:type "text/html; charset=utf-8"
+                :content html}
+               {:type "text/plain; charset=utf-8"
+                :content plain}]
               attachments)]
     (mail/send-message
      conn

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -69,10 +69,13 @@
    html     :- (s/maybe s/Str)
    attachments :- [s/Any]]
   (let [body (concat
-              [{:type "text/html; charset=utf-8"
-                :content html}
+              [:alternative
+               ;; With multipart/alternative, the earlier the part, the lower
+               ;; the priority, so place the plaintext first and the HTML last
                {:type "text/plain; charset=utf-8"
-                :content plain}]
+                :content plain}
+               {:type "text/html; charset=utf-8"
+                :content html}]
               attachments)]
     (mail/send-message
      conn


### PR DESCRIPTION
There is already a template and generated body from the Mustache template,
might as well use it. Sending text/html and text/plain multipart emails is nice
manners.