### PR TITLE
SCM

### DIFF
--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -200,7 +200,10 @@
 (defn git-checkout [repo sha-ish]
   (git repo "checkout" ["-f" sha-ish]))
 
-(defn git-clone [local remote]
-  (.mkdirs (io/file (parent-dir local)))
-  ;; don't worry about local/remote & hardlinks for now
-  (run "clone" [remote local]))
+(defn git-clone
+  ([local remote]
+   (git-clone local remote []))
+  ([local remote args]
+   (.mkdirs (io/file (parent-dir local)))
+   ;; don't worry about local/remote & hardlinks for now
+   (run "clone" (concat [remote local] args))))

--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -200,6 +200,11 @@
 (defn git-checkout [repo sha-ish]
   (git repo "checkout" ["-f" sha-ish]))
 
+(defn git-branch [repo]
+  (-> (git repo "rev-parse" ["--abbrev-ref" "HEAD"])
+      :out
+      str/trim-newline))
+
 (defn git-clone
   ([local remote]
    (git-clone local remote []))

--- a/src/clj/runbld/io.clj
+++ b/src/clj/runbld/io.clj
@@ -46,13 +46,23 @@
                                       (:err res)))
     res))
 
-(defn rmdir-r [dir]
-  (let [listing (->> dir
-                     jio/file
-                     file-seq
-                     reverse)]
-    (doseq [f listing]
-      (jio/delete-file f))))
+(defn lsdir [dir]
+  (->> dir
+       jio/file
+       file-seq
+       reverse))
+
+(defn rmdir-contents
+  "Recursively deletes all files in dir, but not dir itself."
+  [dir]
+  (doseq [f (butlast (lsdir dir))]
+    (jio/delete-file f)))
+
+(defn rmdir-r
+  "Recursively deletes all files in dir, including dir itself."
+  [dir]
+  (doseq [f (lsdir dir)]
+    (jio/delete-file f)))
 
 (defn mkdir-p [dir]
   (.mkdirs (jio/file dir)))

--- a/src/clj/runbld/io.clj
+++ b/src/clj/runbld/io.clj
@@ -47,27 +47,12 @@
     res))
 
 (defn rmdir-r [dir]
-  (let [f (fn [[x & xs]]
-            (when x
-              (cond
-                ;; Leaf (file or empty directory)
-                (or (.isFile x)
-                    (and (.isDirectory x)
-                         (zero? (count (.listFiles x)))))
-                (do
-                  (when (windows?)
-                    (System/gc)
-                    (.setWritable x true))
-                  (again/with-retries [100 500 500]
-                    (jio/delete-file x))
-                  (recur xs))
-
-                ;; Node (non-empty directory)
-                (and (.isDirectory x)
-                     (pos? (count (.listFiles x))))
-                (recur
-                 (concat (.listFiles x) [x] xs)))))]
-    (f [(jio/file dir)])))
+  (let [listing (->> dir
+                     jio/file
+                     file-seq
+                     reverse)]
+    (doseq [f listing]
+      (jio/delete-file f))))
 
 (defn mkdir-p [dir]
   (.mkdirs (jio/file dir)))

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -58,7 +58,7 @@
           (io/log "wiping workspace")
           (clojure.java.shell/sh "find" local "-mindepth" "1" "-delete"))
         (io/log "cloning" remote)
-        (git/git-clone local remote clone-args )
+        (git/git-clone local remote clone-args)
         (io/log "done cloning")))))
 
 (def make-opts

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -44,11 +44,13 @@
 
 (defn bootstrap-workspace [raw-opts]
   (let [clone? (boolean (-> raw-opts :scm :clone))
+        reference (-> raw-opts :scm :reference-repo)
         local (-> raw-opts :process :cwd)
-        remote (-> raw-opts :scm :remote)]
+        remote (-> raw-opts :scm :url)]
     (when clone?
       (io/log "cloning" remote)
-      (git/git-clone local remote)
+      (git/git-clone local remote (when reference
+                                    ["--reference" reference]))
       (io/log "done cloning"))))
 
 (def make-opts

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -48,10 +48,12 @@
         local (-> raw-opts :process :cwd)
         remote (-> raw-opts :scm :url)
         reference (-> raw-opts :scm :reference-repo)
-        branch (-> raw-opts :scm :branch)]
+        branch (-> raw-opts :scm :branch)
+        depth (-> raw-opts :scm :depth)]
     (when clone?
       (let [clone-args (->> [(when reference ["--reference" reference])
-                             (when branch ["--branch" branch])]
+                             (when branch ["--branch" branch])
+                             (when depth ["--depth" (str depth)])]
                             (filter identity)
                             (apply concat))]
         (when wipe-workspace?

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -55,8 +55,9 @@
                             (filter identity)
                             (apply concat))]
         (when wipe-workspace?
-          (io/log "wiping workspace")
-          (clojure.java.shell/sh "find" local "-mindepth" "1" "-delete"))
+          (let [workspace (System/getenv "WORKSPACE")]
+            (io/log "wiping workspace" workspace)
+            (clojure.java.shell/sh "find" workspace "-mindepth" "1" "-delete")))
         (io/log "cloning" remote)
         (git/git-clone local remote clone-args)
         (io/log "done cloning")))))

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -43,10 +43,15 @@
      ;; for tests when #'really-die is redefed
      msg*)))
 
+(defn wipe-workspace [workspace]
+  (io/log "wiping workspace" workspace)
+  (io/rmdir-contents workspace))
+
 (s/defn bootstrap-workspace
   ([raw-opts :- OptsWithLogger]
    (let [clone? (boolean (-> raw-opts :scm :clone))
          wipe-workspace? (boolean (-> raw-opts :scm :wipe-workspace))
+         workspace (System/getenv "WORKSPACE")
          local (-> raw-opts :process :cwd)
          remote (-> raw-opts :scm :url)
          reference (-> raw-opts :scm :reference-repo)
@@ -59,9 +64,7 @@
                              (filter identity)
                              (apply concat))]
          (when wipe-workspace?
-           (let [workspace (System/getenv "WORKSPACE")]
-             (io/log "wiping workspace" workspace)
-             (clojure.java.shell/sh "find" workspace "-mindepth" "1" "-delete")))
+           (wipe-workspace workspace))
          (io/log "cloning" remote)
          (git/git-clone local remote clone-args)
          (io/log "done cloning"))))))

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -170,6 +170,9 @@
    (s/optional-key :node)      s/Str
    (s/optional-key :last-success) LastGoodBuild})
 
+(def OptsWithLogger
+  (merge Opts {:logger clojure.lang.IFn}))
+
 (def OptsWithSys
   (merge Opts {:sys    BuildSystem
                :logger clojure.lang.IFn}))

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -91,7 +91,8 @@
    :url s/Str
    (s/optional-key :reference-repo) s/Str
    :branch s/Str
-   :wipe-workspace s/Bool})
+   :wipe-workspace s/Bool
+   (s/optional-key :depth) s/Int})
 
 (def Opts
   {:job-name   s/Str

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -89,7 +89,7 @@
 (def OptsScm
   {:clone s/Bool
    :url s/Str
-   :reference-repo s/Str})
+   (s/optional-key :reference-repo) s/Str
 
 (def Opts
   {:job-name   s/Str

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -86,9 +86,14 @@
    :bucket     s/Str
    :prefix     s/Str})
 
+(def OptsScm
+  {:clone s/Bool
+   :remote s/Str})
+
 (def Opts
   {:job-name   s/Str
    (s/optional-key :last-good-commit) s/Str
+   (s/optional-key :scm) OptsScm
    :version    VersionInfo
    :configfile (s/maybe s/Str)
    :email      OptsEmail

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -90,6 +90,8 @@
   {:clone s/Bool
    :url s/Str
    (s/optional-key :reference-repo) s/Str
+   :branch s/Str
+   :wipe-workspace s/Bool})
 
 (def Opts
   {:job-name   s/Str

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -88,7 +88,8 @@
 
 (def OptsScm
   {:clone s/Bool
-   :remote s/Str})
+   :url s/Str
+   :reference-repo s/Str})
 
 (def Opts
   {:job-name   s/Str

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -1,0 +1,27 @@
+es:
+  build-index: runbld-build
+  failure-index: runbld-failure
+  log-index: runbld-log
+
+process:
+  env:
+    RUNBLD_TEST: RUNBLD_TEST
+
+email:
+  host: smtp.example.com
+  port: 587
+  user: smtpuser
+  pass: pass!
+  from: default@example.com
+  to: default@example.com
+  template-txt: test/templates/default.mustache
+  template-html: templates/email.mustache.html
+
+profiles:
+  - '^elastic\+foo\+master$':
+      scm:
+        clone: true
+        url: https://github.com/elastic/elasticsearch.git
+        branch: master
+        depth: 1
+        wipe-workspace: true


### PR DESCRIPTION
This adds the ability for runbld to manage cloning itself as opposed to relying on the underlying scheduler. Here's an example config:

```yaml
- '^elastic\+elasticsearch\+master\+periodic':
    scm:
      clone: true
      url: git@github.com:elastic/elasticsearch.git
      reference-repo: /var/lib/jenkins/.git-references/elasticsearch.git
      branch: master
      wipe-workspace: true
      depth: 1
```

This could stand to have an integration test, which I can do soon. I thought it'd be good to get some eyes on this sooner rather than later.