### PR TITLE
Clone the elasticsearch repo as needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ target/
 TEST-*
 /test.log
 /.cider-history
+/test/elasticsearch-src

--- a/README.md
+++ b/README.md
@@ -120,12 +120,6 @@ with copying a ruby file to Mac OS X's default Ruby location.  I
 failed to figure out why and eventually worked around it by
 removing the Ruby deploy directives from the cmake files.
 
-### Elasticsearch source
-
-One test checks the most recent thousand commits from the
-Elasticsearch repo.  The repo should be checked out to
-`$HOME/src/elastic/elasticsearch`
-
 ## Running tests
 
 Once all of the dependencies are installed go to the `runbld`

--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -206,9 +206,31 @@
       str/trim-newline))
 
 (defn git-clone
+  "Clones a git repository.  `local' is either a path that is fully
+  qualified or relative to the current working directory that
+  specifies to where the `remote' repository will be cloned.  `remote'
+  is a standard Git URL.
+
+  The following two are equivalent:
+  clj: (git-clone \"/home/user/src/elasticsearch-source\"
+        \"git@github.com:elastic/elasticsearch.git\")
+
+  cli: git clone git@github.com:elastic/elasticsearch.git \\
+         /home/user/src/elasticsearch-source"
   ([local remote]
    (git-clone local remote []))
   ([local remote args]
    (.mkdirs (io/file (parent-dir local)))
    ;; don't worry about local/remote & hardlinks for now
    (run "clone" (concat [remote local] args))))
+
+(defn git-pull
+  "Runs `git pull' on the provided repo.  `args' is a vector of
+  options as they would be specified on the command line.
+
+  clj: (git-pull repo [\"--rebase\"])
+  cli: git pull --rebase"
+  ([repo]
+   (git-pull repo []))
+  ([repo args]
+   (git repo "pull" args)))

--- a/test/clj_git/test/core_test.clj
+++ b/test/clj_git/test/core_test.clj
@@ -21,7 +21,7 @@
       (flush)
       (git/git-clone
        dir
-       "git@github.com:elastic/elasticsearch.git")))
+       "https://github.com/elastic/elasticsearch.git")))
   (println "  Done."))
 
 (deftest parse-commit

--- a/test/clj_git/test/core_test.clj
+++ b/test/clj_git/test/core_test.clj
@@ -3,13 +3,32 @@
             [clojure.test :refer :all])
   (:require [clj-git.core :as git] :reload-all))
 
+(def es-src-dir (-> "clj_git"
+                    io/resource
+                    io/file
+                    .getParent
+                    (io/file "elasticsearch-src")
+                    .getCanonicalPath))
+
+(defn maybe-prep-repo [dir]
+  (if (.exists (io/file dir ".git"))
+    (do
+      (print "Elasticsearch source already cloned.  Pulling...")
+      (flush)
+      (git/git-pull (git/load-repo dir)))
+    (do
+      (print "Elasticsearch source missing.  Cloning...")
+      (flush)
+      (git/git-clone
+       dir
+       "git@github.com:elastic/elasticsearch.git")))
+  (println "  Done."))
+
 (deftest parse-commit
+  (maybe-prep-repo es-src-dir)
   (time
    (testing "the first thousand commits can parse"
-     (is (= 1000 (->> (io/file
-                       (System/getProperty "user.home")
-                       "src" "elastic" "elasticsearch")
-                      str
+     (is (= 1000 (->> es-src-dir
                       git/load-repo
                       git/git-log
                       (take 1000)


### PR DESCRIPTION
Don't expect the ES repo to exist at some location on disk but rather
clone or update it as needed.