### PR TITLE
Get branch from job name

### DIFF
--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -49,29 +49,29 @@
   (io/rmdir-contents workspace))
 
 (s/defn bootstrap-workspace
-  ([raw-opts :- MainOpts]
-   (let [clone? (boolean (-> raw-opts :scm :clone))
-         wipe-workspace? (boolean (-> raw-opts :scm :wipe-workspace))
-         workspace (System/getenv "WORKSPACE")
-         local (-> raw-opts :process :cwd)
-         remote (-> raw-opts :scm :url)
-         reference (-> raw-opts :scm :reference-repo)
-         branch (or (-> raw-opts :scm :branch)
-                    (-> raw-opts :build :branch))
-         depth (-> raw-opts :scm :depth)]
-     (when clone?
-       (let [clone-args (->> [(when (and reference
-                                         (.exists (jio/as-file reference)))
-                                ["--reference" reference])
-                              (when branch ["--branch" (str branch)])
-                              (when depth ["--depth" (str depth)])]
-                             (filter identity)
-                             (apply concat))]
-         (when wipe-workspace?
-           (wipe-workspace workspace))
-         (io/log "cloning" remote)
-         (git/git-clone local remote clone-args)
-         (io/log "done cloning"))))))
+  [opts :- MainOpts]
+  (let [clone? (boolean (-> opts :scm :clone))
+        wipe-workspace? (boolean (-> opts :scm :wipe-workspace))
+        workspace (System/getenv "WORKSPACE")
+        local (-> opts :process :cwd)
+        remote (-> opts :scm :url)
+        reference (-> opts :scm :reference-repo)
+        branch (or (-> opts :scm :branch)
+                   (-> opts :build :branch))
+        depth (-> opts :scm :depth)]
+    (when clone?
+      (let [clone-args (->> [(when (and reference
+                                        (.exists (jio/as-file reference)))
+                               ["--reference" reference])
+                             (when branch ["--branch" (str branch)])
+                             (when depth ["--depth" (str depth)])]
+                            (filter identity)
+                            (apply concat))]
+        (when wipe-workspace?
+          (wipe-workspace workspace))
+        (io/log "cloning" remote)
+        (git/git-clone local remote clone-args)
+        (io/log "done cloning")))))
 
 (def make-opts
   (-> #'identity
@@ -103,9 +103,7 @@
 ;; -main :: IO ()
 (defn -main [& args]
   (try+
-   (let [raw-opts (assoc
-                   (opts/parse-args args)
-                   :logger io/log)
+   (let [raw-opts (assoc (opts/parse-args args) :logger io/log)
          _ (io/log (version/string))
          opts (make-opts raw-opts)
          _ (bootstrap-workspace opts)

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -49,14 +49,15 @@
   (io/rmdir-contents workspace))
 
 (s/defn bootstrap-workspace
-  ([raw-opts :- OptsWithLogger]
+  ([raw-opts :- MainOpts]
    (let [clone? (boolean (-> raw-opts :scm :clone))
          wipe-workspace? (boolean (-> raw-opts :scm :wipe-workspace))
          workspace (System/getenv "WORKSPACE")
          local (-> raw-opts :process :cwd)
          remote (-> raw-opts :scm :url)
          reference (-> raw-opts :scm :reference-repo)
-         branch (-> raw-opts :scm :branch)
+         branch (or (-> raw-opts :scm :branch)
+                    (-> raw-opts :build :branch))
          depth (-> raw-opts :scm :depth)]
      (when clone?
        (let [clone-args (->> [(when (and reference
@@ -106,8 +107,8 @@
                    (opts/parse-args args)
                    :logger io/log)
          _ (io/log (version/string))
-         _ (bootstrap-workspace raw-opts)
          opts (make-opts raw-opts)
+         _ (bootstrap-workspace opts)
          _ (maybe-log-last-success opts)
          _ (io/log ">>>>>>>>>>>> SCRIPT EXECUTION BEGIN >>>>>>>>>>>>")
          {:keys [opts process-result]} (proc/run opts)

--- a/src/clj/runbld/opts.clj
+++ b/src/clj/runbld/opts.clj
@@ -101,13 +101,17 @@
      "/etc/runbld/runbld.conf")))
 
 (s/defn assemble-all-opts :- java.util.Map
+  "Merge the options gathered from defaults, system config, the config
+  file specified on the command line, and any separate opts specified
+  by command line arguments"
   [{:keys [job-name] :as opts} :- {(s/required-key :job-name) s/Str
                                    s/Keyword s/Any}]
   (deep-merge-with deep-merge
                    config-file-defaults
                    (if (environ/env :dev)
                      (do
-                       (io/log "DEV enabled, not attempting to read" (str (system-config)))
+                       (io/log "DEV enabled, not attempting to read"
+                               (str (system-config)))
                        {})
                      (let [sys (system-config)]
                        (if (.isFile sys)
@@ -192,6 +196,14 @@
      filename)))
 
 (s/defn parse-args :- Opts
+  "Prepares the configuration/options for runbld.  This currently includes:
+  1. reading, parsing, validating the command line args
+  2. printing usage
+  3. gathering information about the JVM and the environment
+  4. connecting to and initializing ES
+  5. writing out the script file that will drive the build
+
+  And returning all of the useful information from the above."
   ([args :- [s/Str]]
    (let [{:keys [options arguments summary errors]
           :as parsed-opts} (cli/parse-opts args opts :nodefault true)]

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -90,7 +90,7 @@
   {:clone s/Bool
    :url s/Str
    (s/optional-key :reference-repo) s/Str
-   :branch s/Str
+   (s/optional-key :branch) s/Str
    :wipe-workspace s/Bool
    (s/optional-key :depth) s/Int})
 

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -170,9 +170,6 @@
    (s/optional-key :node)      s/Str
    (s/optional-key :last-success) LastGoodBuild})
 
-(def OptsWithLogger
-  (merge Opts {:logger clojure.lang.IFn}))
-
 (def OptsWithSys
   (merge Opts {:sys    BuildSystem
                :logger clojure.lang.IFn}))

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -27,3 +27,22 @@ profiles:
         wipe-workspace: true
         # Git should ignore reference repos that aren't accessible.
         reference-repo: /some/fake/path
+
+  - '^owner\+project\+.*':
+      scm:
+        clone: true
+        url: https://github.com/elastic/elasticsearch.git
+        depth: 1
+        wipe-workspace: true
+        # Git should ignore reference repos that aren't accessible.
+        reference-repo: /some/fake/path
+
+  - '^owner\+project\+master$':
+      scm:
+        clone: true
+        url: https://github.com/elastic/elasticsearch.git
+        branch: master
+        depth: 1
+        wipe-workspace: true
+        # Git should ignore reference repos that aren't accessible.
+        reference-repo: /some/fake/path


### PR DESCRIPTION
Reviewing commit-by-commit will be the easiest due to some formatting changes that muddle the diff.

The main crux of the change is to call `bootstrap-workspace` after parsing the args/loading the config.  This allows us to look for the branch name in the `:scm` section of the config as well as in the `:build` section (where it is derived from parsing the job name).
