### PR TITLE
Revisit middleware

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -121,13 +121,18 @@
 
 (s/defn wrap-build-meta :- OptsWithBuild
   [proc :- clojure.lang.IFn]
-  (fn [opts*]
-    (let [opts (assoc opts*
-                      :id (make-id)
-                      :build (merge (:build opts*)
-                                    (split-job-name (:job-name opts*))
-                                    (scheduler/as-map (:scheduler opts*))))
-          [last-good-build checked-out?]
+  (fn [opts]
+    (proc
+     (assoc opts
+            :id (make-id)
+            :build (merge (:build opts)
+                          (split-job-name (:job-name opts))
+                          (scheduler/as-map (:scheduler opts)))))))
+
+(s/defn wrap-last-success
+  [proc :- clojure.lang.IFn]
+  (fn [opts]
+    (let [[last-good-build checked-out?]
           (maybe-find-last-good-build-and-checkout opts)]
       (proc
        (update-in

--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -119,24 +119,41 @@
    :commit-id (-> last-good-build :vcs :commit-id)
    :job-name (-> last-good-build :build :job-name)})
 
-(s/defn wrap-build-meta :- OptsWithBuild
-  [proc :- clojure.lang.IFn]
-  (fn [opts]
-    (proc
-     (assoc opts
-            :id (make-id)
-            :build (merge (:build opts)
-                          (split-job-name (:job-name opts))
-                          (scheduler/as-map (:scheduler opts)))))))
+(s/defn add-build-meta ;; :- OptsWithBuild
+  [opts]
+  (assoc opts
+         :id (make-id)
+         :build (merge (:build opts)
+                       (split-job-name (:job-name opts))
+                       (scheduler/as-map (:scheduler opts)))))
 
-(s/defn wrap-last-success
-  [proc :- clojure.lang.IFn]
-  (fn [opts]
-    (let [[last-good-build checked-out?]
-          (maybe-find-last-good-build-and-checkout opts)]
-      (proc
-       (update-in
-        opts [:build] merge (when last-good-build
-                              {:last-success
-                               (abbreviate-last-good-build
-                                last-good-build checked-out?)}))))))
+(s/defn add-last-success
+  [opts]
+  (let [[last-good-build checked-out?]
+        (maybe-find-last-good-build-and-checkout opts)]
+    (update
+     opts :build merge (when last-good-build
+                         {:last-success
+                          (abbreviate-last-good-build
+                           last-good-build checked-out?)}))))
+
+(defn maybe-log-last-success [opts]
+  (when (-> opts :build :last-success :checked-out)
+    (let [b (find-build opts (-> opts :build :last-success :id))
+          commit (-> b :vcs :commit-short)]
+      ((:logger opts)
+       "using last successful commit"
+       commit
+       "from"
+       (-> b :build :job-name) (-> b :id)
+       (-> b :process :time-start)
+       (date/human-duration
+        (date/iso-diff-secs
+         (date/from-iso
+          ;; notify on time-end because it makes more
+          ;; logical sense to report on the last
+          ;; completed build's end time, I think
+          (-> b :process :time-end))
+         (date/now)))
+       "ago")))
+  opts)

--- a/src/clj/runbld/java.clj
+++ b/src/clj/runbld/java.clj
@@ -66,13 +66,10 @@
                               (:home props)))]
      (assoc props :home adjusted-java-home))))
 
-(s/defn wrap-java
-  [proc]
-  (fn [opts]
-    (if (get-in opts [:java :home])
-      (proc opts)
-      (let [facts (jvm-facts (:bootstrap-java-home opts))]
-        (proc
-         (-> opts
-             (merge facts)
-             (assoc-in [:process :env :JAVA_HOME] (:home facts))))))))
+(defn add-java [opts]
+  (if (get-in opts [:java :home])
+    opts
+    (let [facts (jvm-facts (:bootstrap-java-home opts))]
+      (-> opts
+          (merge facts)
+          (assoc-in [:process :env :JAVA_HOME] (:home facts))))))

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -46,14 +46,25 @@
      ;; for tests when #'really-die is redefed
      msg*)))
 
-(defn wipe-workspace [opts]
+(defn find-workspace
+  "just to override in tests"
+  []
+  (System/getenv "WORKSPACE"))
+
+(s/defn wipe-workspace
+  [opts :- {(s/optional-key :scm) OptsScm
+            s/Keyword s/Any}]
   (when (boolean (-> opts :scm :wipe-workspace))
-    (let [workspace (System/getenv "WORKSPACE")]
+    (let [workspace (find-workspace)]
       (io/log "wiping workspace" workspace)
       (io/rmdir-contents workspace)))
   opts)
 
-(s/defn bootstrap-workspace [opts]
+(s/defn bootstrap-workspace
+  [opts :- {:process OptsProcess
+            :build Build
+            (s/optional-key :scm) OptsScm
+            s/Keyword s/Any}]
   (let [clone? (boolean (-> opts :scm :clone))
         local (-> opts :process :cwd)
         remote (-> opts :scm :url)
@@ -74,31 +85,53 @@
         (io/log "done cloning"))))
   opts)
 
-(defn log-script-execution [proc opts]
+(s/defn log-script-execution
+  [proc :- clojure.lang.IFn
+   opts]
   (io/log ">>>>>>>>>>>> SCRIPT EXECUTION BEGIN >>>>>>>>>>>>")
-  (let [{:keys [opts process-result] :as res} (proc opts)
+  (let [{:keys [process-result] :as opts} (proc opts)
         {:keys [took status exit-code out-bytes err-bytes]} process-result]
     (io/log "<<<<<<<<<<<< SCRIPT EXECUTION END <<<<<<<<<<<<")
     (io/log (format "DURATION: %sms" took))
     (io/log (format "STDOUT: %d bytes" out-bytes))
     (io/log (format "STDERR: %d bytes" err-bytes))
     (io/log (format "WRAPPED PROCESS: %s (%d)" status exit-code))
-    res))
+    opts))
 
-(defn test-report [opts]
+(s/defn test-report :- {:test-report TestReport
+                        s/Keyword s/Any}
+  [opts :- {:process OptsProcess
+            s/Keyword s/Any}]
   (assoc opts :test-report (tests/report (-> opts :process :cwd))))
 
-(defn store-result [{:keys [test-report process-result] :as opts}]
-  (assoc opts :store-result
-         (store/save! opts process-result test-report)))
+(s/defn store-result :- {:store-result {s/Keyword s/Any}
+                         s/Keyword s/Any}
+  [opts :- {:test-report TestReport
+            :process-result ProcessResult
+            s/Keyword s/Any}]
+  (let [{:keys [test-report process-result]} opts]
+    (assoc opts :store-result
+           (store/save! opts process-result test-report))))
 
-(defn send-slack [{:keys [store-result] :as opts}]
+(s/defn send-slack :- {:slack-result s/Any
+                       s/Keyword s/Any}
+  [opts :- {:store-result {:addr {s/Keyword s/Any}
+                           :url s/Str
+                           :build-doc {s/Keyword s/Any}}
+            :slack OptsSlack
+            s/Keyword s/Any}]
   (assoc opts :slack-result
-         (io/try-log (slack/maybe-send! opts (:addr store-result)))))
+         (io/try-log (slack/maybe-send! opts (-> opts :store-result :addr)))))
 
-(defn send-email [{:keys [store-result] :as opts}]
+(s/defn send-email :- {:email-result s/Any
+                       s/Keyword s/Any}
+  [opts :- {:store-result {:addr {s/Keyword s/Any}
+                           :url s/Str
+                           :build-doc {s/Keyword s/Any}}
+            :email OptsEmail
+            s/Keyword s/Any}]
   (assoc opts :email-result
-         (io/try-log (email/maybe-send! opts (:addr store-result)))))
+         (io/try-log (email/maybe-send! opts (-> opts :store-result :addr)))))
 
 (def default-middleware
   "Middleware that runs during runbld processing. See the docs on
@@ -109,9 +142,9 @@
   [(before java/add-java)
    (before scheduler/add-scheduler)
    (before build/add-build-meta)
-   (before system/add-system-facts)
    (before wipe-workspace)
    (before bootstrap-workspace)
+   (before system/add-system-facts)
    (before vcs/add-vcs-info)
    (before build/add-last-success)
    (before build/maybe-log-last-success)

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -101,15 +101,11 @@
          (io/try-log (email/maybe-send! opts (:addr store-result)))))
 
 (def default-middleware
-  "Middleware that runs during runbld processing.  Will be processed
-  in order, top to bottom.  Use the before, after, and around macros
-  for clarity.
+  "Middleware that runs during runbld processing. See the docs on
+  runbld.pipeline/make-pipeline for more information.
 
   Order matters as there are stages that may rely on information from
-  previous stages.  Pay particular attention to before/after because
-  in the case of 'before' the order is top to bottom but in the case
-  of 'after' the order is bottom to top, relative to other 'after'
-  functions."
+  previous stages.  Pay particular attention to before/after."
   [(before java/add-java)
    (before scheduler/add-scheduler)
    (before build/add-build-meta)

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -100,7 +100,7 @@
    (slurp (io/resolve-resource tmpl)) ctx))
 
 (s/defn send :- s/Any
-  [opts :- MainOpts
+  [opts
    ctx :- EmailCtx]
   ;; If needing to regenerate for render tests
   #_(spit "test/context.edn"

--- a/src/clj/runbld/pipeline.clj
+++ b/src/clj/runbld/pipeline.clj
@@ -78,11 +78,11 @@
                                     ▲
        MIDDLEWARE      1. before1 │ │ 9. after1
          before1                  │ │
-         after1        2. before2 │ │ 8. after3
-         before                   │ │
-         around        3.  around │ │ 7. around
+         after1        2. before2 │ │ 8. around
+         before2                  │ │
+         around        3.  around │ │ 7. after2
          after2                   │ │
-         before3       4. before3 │ │ 6. after2
+         before3       4. before3 │ │ 6. after3
          after3                   │ │
                                   ▼
                           5. root function"

--- a/src/clj/runbld/pipeline.clj
+++ b/src/clj/runbld/pipeline.clj
@@ -68,7 +68,25 @@
              _# (debug-log :leave name# (keys res#))]
          res#))))
 
-(defn make-pipeline [root-fn middleware-list]
+(defn make-pipeline
+  "Wraps 'root-fn' in the middleware provided in middleware-list.  The
+  following diagram illustrates the order of processing.  The list of
+  middleware is on the left, and the order follows, starting at
+  'before1' down until 'root function' is called and the proceeds back
+  up until it ends at 'after1' and the final map is returned.
+
+                                    ▲
+       MIDDLEWARE      1. before1 │ │ 9. after1
+         before1                  │ │
+         after1        2. before2 │ │ 8. after3
+         before                   │ │
+         around        3.  around │ │ 7. around
+         after2                   │ │
+         before3       4. before3 │ │ 6. after2
+         after3                   │ │
+                                  ▼
+                          5. root function"
+  [root-fn middleware-list]
   (reduce (fn wrap-proc* [proc middleware]
             (middleware proc))
           (fn [opts]

--- a/src/clj/runbld/pipeline.clj
+++ b/src/clj/runbld/pipeline.clj
@@ -1,0 +1,79 @@
+(ns runbld.pipeline
+  (:require [runbld.io :as io]))
+
+(def debug-middleware?
+  "Set to true to enable debug logging during before/after/around"
+  true)
+
+(defn symbol-name [fn-sym]
+  (try
+    `(:name (meta (var ~fn-sym)))
+    (catch Exception _
+      `(str ~fn-sym))))
+
+(defn debug-log [& x]
+  (when debug-middleware?
+    (apply io/log x)))
+
+(defmacro before [fn-sym]
+  "Returns a middleware function that will run before the wrapped
+  function runs.  The passed function is expected to take 1 argument,
+  opts and must return opts when it is done.
+
+  e.g.,
+  (defun my-before-fn [opts] ...)
+  (before my-before-fn)"
+  `(fn [proc#]
+     (fn [opts#]
+       (let [name# ~(symbol-name fn-sym)
+             _# (debug-log :enter name# (keys opts#))
+             res# (~fn-sym opts#)
+             _# (debug-log :after-fn name# (keys res#))
+             proc-res# (proc# res#)]
+         (debug-log :after-proc name# (keys proc-res#))
+         proc-res#))))
+
+(defmacro after [fn-sym]
+  "Returns a middleware function that will run after the wrapped
+  function runs.  The passed function is expected to take 1 argument,
+  opts and must return opts when it is done.
+
+  e.g.,
+  (defun my-after-fn [opts] ...)
+  (after my-after-fn)"
+  `(fn [proc#]
+     (fn [opts#]
+       (let [name# ~(symbol-name fn-sym)
+             _# (debug-log :enter name# (keys opts#))
+             res# (proc# opts#)
+             _# (debug-log :after-proc name# (keys res#))
+             fn-res# (~fn-sym res#)]
+         (debug-log :after-fn name# (keys fn-res#))
+         fn-res#))))
+
+(defmacro around [fn-sym]
+  "Returns a middleware function that will run both before and after
+  the wrapped function runs.  This one is different from before and
+  after because the passed `opts-fn' is expected to take 2 arguments,
+  proc and opts and is expected to call `proc' and return the results.
+
+  e.g.,
+  (defun my-around-fn [proc opts] ...)
+  (around my-around-fn)"
+  `(fn [proc#]
+     (fn [opts#]
+       (let [name# ~(symbol-name fn-sym)
+             _# (debug-log :enter name# (keys opts#))
+             res# (~fn-sym proc# opts#)
+             _# (debug-log :leave name# (keys res#))]
+         res#))))
+
+(defn make-pipeline [root-fn middleware-list]
+  (reduce (fn wrap-proc* [proc middleware]
+            (middleware proc))
+          (fn [opts]
+            (debug-log :before-root-proc (keys opts))
+            (let [res (root-fn opts)]
+              (debug-log :after-root-proc (keys opts))
+              res))
+          (reverse middleware-list)))

--- a/src/clj/runbld/pipeline.clj
+++ b/src/clj/runbld/pipeline.clj
@@ -3,7 +3,7 @@
 
 (def debug-middleware?
   "Set to true to enable debug logging during before/after/around"
-  true)
+  false)
 
 (defn symbol-name [fn-sym]
   (try

--- a/src/clj/runbld/process.clj
+++ b/src/clj/runbld/process.clj
@@ -228,16 +228,13 @@
        :total-bytes total-bytes}))))
 
 (def RunOpts
-  {:process OptsProcess
-   :es      OptsElasticsearch
-   :id      s/Str
-   s/Any    s/Any})
+  {:process  OptsProcess
+   :es       OptsElasticsearch
+   :id       s/Str
+   s/Keyword s/Any})
 
-(s/defn run
-  ;; :- {:opts RunOpts
-  ;;     :process-result ProcessResult}
-  [opts ;;:- RunOpts
-   ]
+(s/defn run :- (assoc RunOpts :process-result ProcessResult)
+  [opts :- RunOpts]
   (assoc opts
          :process-result
          (exec-with-capture

--- a/src/clj/runbld/process.clj
+++ b/src/clj/runbld/process.clj
@@ -233,17 +233,19 @@
    :id      s/Str
    s/Any    s/Any})
 
-(s/defn run :- {:opts RunOpts
-                :process-result ProcessResult}
-  [opts :- RunOpts]
-  {:opts opts
-   :process-result
-   (exec-with-capture
-    (-> opts :process :program)
-    (-> opts :process :args)
-    (-> opts :process :scriptfile)
-    (-> opts :process :cwd)
-    (-> opts :process :output)
-    (-> opts :es)
-    (-> opts :process :env)
-    {:build-id (-> opts :id)})})
+(s/defn run
+  ;; :- {:opts RunOpts
+  ;;     :process-result ProcessResult}
+  [opts ;;:- RunOpts
+   ]
+  (assoc opts
+         :process-result
+         (exec-with-capture
+          (-> opts :process :program)
+          (-> opts :process :args)
+          (-> opts :process :scriptfile)
+          (-> opts :process :cwd)
+          (-> opts :process :output)
+          (-> opts :es)
+          (-> opts :process :env)
+          {:build-id (-> opts :id)})))

--- a/src/clj/runbld/scheduler/middleware.clj
+++ b/src/clj/runbld/scheduler/middleware.clj
@@ -15,8 +15,6 @@
 
     :else (default/make opts)))
 
-(s/defn wrap-scheduler :- OptsWithScheduler
-  [proc]
-  (fn [opts]
-    (proc
-     (assoc opts :scheduler (make-scheduler opts)))))
+(s/defn add-scheduler ;; :- OptsWithScheduler
+  [opts]
+  (assoc opts :scheduler (make-scheduler opts)))

--- a/src/clj/runbld/scheduler/middleware.clj
+++ b/src/clj/runbld/scheduler/middleware.clj
@@ -15,6 +15,7 @@
 
     :else (default/make opts)))
 
-(s/defn add-scheduler ;; :- OptsWithScheduler
+(s/defn add-scheduler :- {:scheduler (s/protocol scheduler/Scheduler)
+                          s/Keyword s/Any}
   [opts]
   (assoc opts :scheduler (make-scheduler opts)))

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -106,7 +106,8 @@
    :process    OptsProcess
    :s3         OptsS3
    :java       JavaProperties
-   :env        Env})
+   :env        Env
+   s/Keyword s/Any})
 
 (def BuildSystem
   {:arch                   s/Str
@@ -171,24 +172,26 @@
    (s/optional-key :last-success) LastGoodBuild})
 
 (def OptsWithSys
-  (merge Opts {:sys    BuildSystem
-               :logger clojure.lang.IFn}))
+  (merge Opts
+         {:sys    BuildSystem
+          :logger clojure.lang.IFn}))
 
 (def OptsWithEnv
-  (merge OptsWithSys {:env Env}))
+  (merge Opts {:env Env}))
 
 (def OptsWithJava
-  (merge OptsWithEnv {:java JavaProperties}))
+  (merge Opts {:java JavaProperties}))
 
 (def OptsWithScheduler
-  (merge OptsWithJava {:scheduler (s/protocol Scheduler)}))
+  (merge Opts {:scheduler (s/protocol Scheduler)}))
 
 (def OptsWithBuild
-  (merge OptsWithScheduler {:id    s/Str
-                            :build Build}))
+  (merge Opts
+         {:id    s/Str
+          :build Build}))
 
 (def MainOpts
-  (merge OptsWithBuild {:vcs {s/Keyword s/Any}}))
+  (merge Opts {:vcs {s/Keyword s/Any}}))
 
 (def ProcessResult
   (merge

--- a/src/clj/runbld/store.clj
+++ b/src/clj/runbld/store.clj
@@ -131,8 +131,8 @@
      :build-doc d}))
 
 (s/defn create-failure-docs :- [StoredFailure]
-  [opts :- MainOpts
-   result :- ProcessResult
+  [opts  ;; :- MainOpts
+   result ;; :- ProcessResult
    failures :- [FailedTestCase]]
   (map #(assoc %
                :build-id (:id opts)
@@ -151,9 +151,10 @@
                              :query-params {:refresh true}}))))
 
 (s/defn save! :- {s/Keyword s/Any}
-  ([opts        :- MainOpts
-    result      :- ProcessResult
-    test-report :- TestReport]
+  ([opts        ;; :- MainOpts
+    result      ;; :- ProcessResult
+    test-report ;; :- TestReport
+    ]
    (when (:report-has-tests test-report)
      ((opts :logger) (format "FAILURES: %d"
                              (count

--- a/src/clj/runbld/store.clj
+++ b/src/clj/runbld/store.clj
@@ -131,8 +131,8 @@
      :build-doc d}))
 
 (s/defn create-failure-docs :- [StoredFailure]
-  [opts  ;; :- MainOpts
-   result ;; :- ProcessResult
+  [opts :- MainOpts
+   result :- ProcessResult
    failures :- [FailedTestCase]]
   (map #(assoc %
                :build-id (:id opts)
@@ -151,10 +151,9 @@
                              :query-params {:refresh true}}))))
 
 (s/defn save! :- {s/Keyword s/Any}
-  ([opts        ;; :- MainOpts
-    result      ;; :- ProcessResult
-    test-report ;; :- TestReport
-    ]
+  ([opts :- MainOpts
+    result :- ProcessResult
+    test-report :- TestReport]
    (when (:report-has-tests test-report)
      ((opts :logger) (format "FAILURES: %d"
                              (count

--- a/src/clj/runbld/system.clj
+++ b/src/clj/runbld/system.clj
@@ -77,8 +77,7 @@
       (make-fs cwd)
       (make-hosting facter)))))
 
-(s/defn wrap-system :- OptsWithSys
-  [proc :- clojure.lang.IFn]
-  (fn [opts]
-    (proc (assoc opts :sys (inspect-system
-                            (-> opts :process :cwd))))))
+(s/defn add-system-facts ;; :- OptsWithSys
+  [opts]
+  (assoc opts :sys (inspect-system
+                    (-> opts :process :cwd))))

--- a/src/clj/runbld/system.clj
+++ b/src/clj/runbld/system.clj
@@ -77,7 +77,7 @@
       (make-fs cwd)
       (make-hosting facter)))))
 
-(s/defn add-system-facts ;; :- OptsWithSys
-  [opts]
+(s/defn add-system-facts :- OptsWithSys
+  [opts :- Opts]
   (assoc opts :sys (inspect-system
                     (-> opts :process :cwd))))

--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -35,5 +35,5 @@
               :opts opts}))))
 
 (s/defn add-vcs-info
-  [opts]
+  [opts :- OptsWithBuild]
   (assoc opts :vcs (vcs/log-latest (make-repo opts))))

--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -34,9 +34,6 @@
                            cwd)
               :opts opts}))))
 
-(s/defn wrap-vcs-info :- MainOpts
-  [proc :- clojure.lang.IFn]
-  (s/fn [opts :- OptsWithBuild]
-    (proc
-     (assoc opts :vcs (vcs/log-latest
-                       (make-repo opts))))))
+(s/defn add-vcs-info
+  [opts]
+  (assoc opts :vcs (vcs/log-latest (make-repo opts))))

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -223,7 +223,8 @@
   (testing "the scm build can be set multiple ways:"
     (let [args (atom [])]
       (with-redefs [git-clone (fn [_ _ clone-args]
-                                (reset! args clone-args))]
+                                (reset! args clone-args))
+                    main/wipe-workspace (fn [workspace] nil)]
         (testing "supplying branch in yml"
           (git/with-tmp-repo [d "tmp/git/owner+project+branch"]
             (let [raw-opts (-> (opts/parse-args

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -13,6 +13,7 @@
             [runbld.notifications.slack :as slack]
             [runbld.opts :as opts]
             [runbld.process :as proc]
+            [runbld.scheduler :as scheduler]
             [runbld.store :as store]
             [runbld.test.support :as ts]
             [runbld.util.http :refer [wrap-retries]]
@@ -224,7 +225,8 @@
     (let [args (atom [])]
       (with-redefs [git-clone (fn [_ _ clone-args]
                                 (reset! args clone-args))
-                    main/wipe-workspace (fn [workspace] nil)]
+                    main/wipe-workspace (fn [workspace] nil)
+                    scheduler/as-map identity]
         (testing "supplying branch in yml"
           (git/with-tmp-repo [d "tmp/git/owner+project+branch"]
             (let [raw-opts (-> (opts/parse-args
@@ -233,7 +235,7 @@
                                  "-d" "tmp/git/owner+project+branch"
                                  "test/fail.bash"])
                                (assoc :logger runbld.io/log))
-                  opts (runbld.main/make-opts raw-opts)]
+                  opts (build/add-build-meta raw-opts)]
               (main/bootstrap-workspace
                (assoc-in opts [:scm :wipe-workspace] false))
               (is (= "master"
@@ -250,7 +252,7 @@
                                 "test/fail.bash")
                                opts/parse-args
                                (assoc :logger runbld.io/log))
-                  opts (runbld.main/make-opts raw-opts)]
+                  opts (build/add-build-meta raw-opts)]
               (main/bootstrap-workspace
                (assoc-in opts [:scm :wipe-workspace] false))
               (is (nil? (-> opts :scm :branch)))


### PR DESCRIPTION
Ok, one at a time: 

* Commit 429f661 was the actual bug that caused failures like the following:
   https://elasticsearch-ci.elastic.co/view/All/job/elastic+elasticsearch+5.4+java9-periodic/503/console

   That particular error appears to come from the fact that the workspace already exists, but is older than the most recent ```last-good-build``` that is stored.  The issue *really* is that ```wipe-workspace``` and ```bootstrap-workspace``` should have happened prior to the ```last-good-build``` stuff in ```build.clj```.

* Commit 7f27724 is an attempt to clean up the middleware used in runbld.  While I think this is better, I'm still a bit ambivalent about the approach.  If it still hurts us, we can fix it later.

* Commit 711f6bf adds a super sweet docstring.

* Commit 7bd22dd reworks some schemas.  Speaking of ambivalence, I'm on the fence here, too.  I guess I need to play with it more and maybe with clojure.spec before deciding.