### PR TITLE
Ensure git args are strings

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -55,4 +55,5 @@
   :aot :all
   :main runbld.main
   :test-selectors {:default (complement :integration)
-                   :integration :integration})
+                   :integration :integration
+                   :all (constantly true)})

--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -31,7 +31,12 @@
    (run cmd args "."))
   ([cmd args dir]
    #_(prn cmd args dir)
-   (let [res (apply sh/sh "git" cmd (concat args [:dir dir]))
+   ;; sh/sh will eventually call clojure.java.shell/parse-args which
+   ;; will `split-with string?` and will assume the second group is
+   ;; a map.  Long story short, make sure that all of our args are
+   ;; strings.
+   (let [args (map str args)
+         res (apply sh/sh "git" cmd (concat args [:dir dir]))
          err (fn [r]
                (assert
                 (= 0 (:exit r)) (format "%s: \nout: %s\nerr: %s"

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -65,7 +65,11 @@
   branch."
   [local branch depth]
   (let [repo (git/load-repo local)]
-    (io/log "repo already cloned" local)
+    (io/log "repo already cloned"
+            "local:" local
+            "branch:" branch
+            "depth:" depth
+            "repo:" repo)
     (io/log "updating")
     (git/git-remote repo ["set-branches" "origin" branch])
     (let [fetch-args (concat (when depth

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -69,8 +69,8 @@
     (io/log "updating")
     (git/git-remote repo ["set-branches" "origin" branch])
     (let [fetch-args (concat (when depth
-                               ["--depth" (str depth)])
-                             ["origin" (str branch)])]
+                               ["--depth" depth])
+                             ["origin" branch])]
       (git/git-fetch repo fetch-args))
     (git/git-checkout repo branch)
     (git/git-pull repo)
@@ -94,8 +94,8 @@
         (let [clone-args (->> [(when (and reference
                                           (.exists (jio/as-file reference)))
                                  ["--reference" reference])
-                               (when branch ["--branch" (str branch)])
-                               (when depth ["--depth" (str depth)])]
+                               (when branch ["--branch" branch])
+                               (when depth ["--depth" depth])]
                               (filter identity)
                               (apply concat))]
           (io/log "cloning" remote)


### PR DESCRIPTION
A non-string arg in the call to ```git-remote``` causes the following: https://elasticsearch-ci.elastic.co/job/elastic+elasticsearch+5.x+packaging-tests/435/console

I'm forcing all of the args to be strings, BUT, there remains the question of why / how a non-string was present.  To that end, I also added a bit of logging.