### PR TITLE
Read branch (or commit) from env

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -47,7 +47,7 @@
                  [slingshot "0.12.2"]
                  [stencil "0.5.0"]]
   :injections [(require 'clojure.pprint)]
-  :profiles {:dev {:env {:dev true}}
+  :profiles {:dev {:env {:dev "true"}}
              :package {:plugins [[elastic/lein-bin "0.3.6"]]
                        :bin {:bootclasspath false}}}
   :plugins [[lein-environ "1.0.3"]]

--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -264,3 +264,8 @@
   options as they would be specified on the command line."
   [repo args]
   (git repo "remote" args))
+
+(defn shallow-clone?
+  "Returns true if the repo is shallow, false otherwise."
+  [repo]
+  (.exists (io/file (:path repo) ".git" "shallow")))

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -152,3 +152,13 @@
     (if (send? (-> opts :email) build-doc)
       (send opts (make-context opts build-doc failure-docs))
       ((opts :logger) "NO MAIL GENERATED"))))
+
+(s/defn send-email :- {:email-result s/Any
+                       s/Keyword s/Any}
+  [opts :- {:store-result {:addr {s/Keyword s/Any}
+                           :url s/Str
+                           :build-doc {s/Keyword s/Any}}
+            :email OptsEmail
+            s/Keyword s/Any}]
+  (assoc opts :email-result
+         (io/try-log (maybe-send! opts (-> opts :store-result :addr)))))

--- a/src/clj/runbld/notifications/slack.clj
+++ b/src/clj/runbld/notifications/slack.clj
@@ -79,3 +79,13 @@
             ((opts :logger)
              (str "Caught exception while notifying Slack: "
                   (.getMessage e)))))))))
+
+(s/defn send-slack :- {:slack-result s/Any
+                       s/Keyword s/Any}
+  [opts :- {:store-result {:addr {s/Keyword s/Any}
+                           :url s/Str
+                           :build-doc {s/Keyword s/Any}}
+            :slack OptsSlack
+            s/Keyword s/Any}]
+  (assoc opts :slack-result
+         (io/try-log (maybe-send! opts (-> opts :store-result :addr)))))

--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -1,0 +1,68 @@
+(ns runbld.scm
+  (:require
+   [clj-git.core :as git]
+   [clojure.java.io :as jio]
+   [runbld.io :as io]
+   [runbld.schema :refer :all]
+   [schema.core :as s]))
+
+(defn find-workspace
+  "just to override in tests"
+  []
+  (System/getenv "WORKSPACE"))
+
+(s/defn wipe-workspace
+  [opts :- {(s/optional-key :scm) OptsScm
+            s/Keyword s/Any}]
+  (when (boolean (-> opts :scm :wipe-workspace))
+    (let [workspace (find-workspace)]
+      (io/log "wiping workspace" workspace)
+      (io/rmdir-contents workspace)))
+  opts)
+
+(defn update-workspace
+  "Updates an existing workspace and gets it onto the correct
+  branch."
+  [local branch depth]
+  (let [repo (git/load-repo local)]
+    (io/log "repo already cloned."
+            "local:" local
+            "branch:" branch
+            "depth:" depth
+            "repo:" repo)
+    (io/log "updating")
+    (git/git-remote repo ["set-branches" "origin" branch])
+    (let [fetch-args (concat (when depth
+                               ["--depth" depth])
+                             ["origin" branch])]
+      (git/git-fetch repo fetch-args))
+    (git/git-checkout repo branch)
+    (git/git-pull repo)
+    (io/log "done updating")))
+
+(s/defn bootstrap-workspace
+  [opts :- {:process OptsProcess
+            :build Build
+            (s/optional-key :scm) OptsScm
+            s/Keyword s/Any}]
+  (let [clone? (boolean (-> opts :scm :clone))
+        local (-> opts :process :cwd)
+        remote (-> opts :scm :url)
+        reference (-> opts :scm :reference-repo)
+        branch (or (-> opts :scm :branch)
+                   (-> opts :build :branch))
+        depth (-> opts :scm :depth)]
+    (when clone?
+      (if (.exists (jio/file local ".git"))
+        (update-workspace local branch depth)
+        (let [clone-args (->> [(when (and reference
+                                          (.exists (jio/as-file reference)))
+                                 ["--reference" reference])
+                               (when branch ["--branch" branch])
+                               (when depth ["--depth" depth])]
+                              (filter identity)
+                              (apply concat))]
+          (io/log "cloning" remote)
+          (git/git-clone local remote clone-args)
+          (io/log "done cloning")))))
+  opts)

--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -2,9 +2,11 @@
   (:require
    [clj-git.core :as git]
    [clojure.java.io :as jio]
+   [environ.core :as environ]
    [runbld.io :as io]
    [runbld.schema :refer :all]
-   [schema.core :as s]))
+   [schema.core :as s]
+   [clojure.string :as str]))
 
 (defn find-workspace
   "just to override in tests"
@@ -20,27 +22,85 @@
       (io/rmdir-contents workspace)))
   opts)
 
+(defn checkout-commit
+  [local commit]
+  (let [repo (git/load-repo local)]
+    (io/log (format "Specific commit specified, %s.  Fetching." commit))
+    (git/git-checkout repo commit)
+    (io/log "Done fetching.")))
+
 (defn update-workspace
   "Updates an existing workspace and gets it onto the correct
   branch."
   [local branch depth]
   (let [repo (git/load-repo local)]
-    (io/log "repo already cloned."
-            "local:" local
-            "branch:" branch
-            "depth:" depth
-            "repo:" repo)
-    (io/log "updating")
+    (io/log "Repo already cloned in" local)
+    (io/log "Updating branch to" branch "with depth" depth)
     (git/git-remote repo ["set-branches" "origin" branch])
     (let [fetch-args (concat (when depth
                                ["--depth" depth])
                              ["origin" branch])]
       (git/git-fetch repo fetch-args))
     (git/git-checkout repo branch)
-    (git/git-pull repo)
-    (io/log "done updating")))
+    (io/log "Done updating branch.")))
+
+(defn clone-workspace
+  "Clones a git repo at the specified branch and depth.  If the local
+  reference repo is available, clone from there to save time."
+  [local remote reference branch depth]
+  (let [clone-args (->> [(when (and reference
+                                    (.exists (jio/as-file reference)))
+                           ["--reference" reference])
+                         (when branch ["--branch" (str branch)])
+                         (when depth ["--depth" (str depth)])]
+                        (filter identity)
+                        (apply concat))]
+    (io/log "cloning" remote)
+    (git/git-clone local remote clone-args)
+    (io/log "done cloning")))
+
+(defn choose-branch
+  "Select the branch (or commit) to checkout.  The branch is chosen
+  from the environment (i.e., where Jenkins puts build parameters), or
+  from the scm config, or finally from the job name.  Since Jenkins
+  always injects parameters we will ignore them if the injected value
+  is the default which is 'refs/heads/{branch-from-job-name}' by
+  convention.
+
+  In the case where commits are present, the commit in the highest
+  priority position will be chosen along with the first branch
+  found (or master as a default).
+
+  non-default-env > scm-config > job-name"
+  [opts]
+  (let [;; the branch name, if any, specified in the scm opts
+        scm-branch (-> opts :scm :branch)
+        ;; the branch name parsed out of the job name
+        build-branch (-> opts :build :branch)
+        ;; the branch name injected into the env by Jenkins
+        env-branch (environ/env :branch-specifier)
+        ;; the default branch that Jenkins will send unless it's overridden
+        default-env-branch (str "refs/heads/" build-branch)
+        commit? (fn [x]
+                  (and
+                   (string? x)
+                   (boolean
+                    (re-matches #"^[a-fA-F0-9]{5,40}$"
+                                (str/trim x)))))]
+    (let [branches (cond->> [build-branch]
+                     (and (not (empty? scm-branch)))
+                     (cons scm-branch)
+
+                     (and (not (empty? env-branch))
+                          (not= default-env-branch env-branch))
+                     (cons env-branch))
+          commit (first (take-while commit? branches))
+          branch (first (drop-while commit? branches))]
+      {:commit commit :branch (or branch "master")})))
 
 (s/defn bootstrap-workspace
+  "Prepare the local workspace by cloning or updating the repository,
+  as necessary."
   [opts :- {:process OptsProcess
             :build Build
             (s/optional-key :scm) OptsScm
@@ -49,20 +109,12 @@
         local (-> opts :process :cwd)
         remote (-> opts :scm :url)
         reference (-> opts :scm :reference-repo)
-        branch (or (-> opts :scm :branch)
-                   (-> opts :build :branch))
+        {:keys [branch commit]} (choose-branch opts)
         depth (-> opts :scm :depth)]
     (when clone?
       (if (.exists (jio/file local ".git"))
         (update-workspace local branch depth)
-        (let [clone-args (->> [(when (and reference
-                                          (.exists (jio/as-file reference)))
-                                 ["--reference" reference])
-                               (when branch ["--branch" branch])
-                               (when depth ["--depth" depth])]
-                              (filter identity)
-                              (apply concat))]
-          (io/log "cloning" remote)
-          (git/git-clone local remote clone-args)
-          (io/log "done cloning")))))
+        (clone-workspace local remote reference branch depth))
+      (when commit
+        (checkout-commit local commit))))
   opts)

--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -1,6 +1,7 @@
 (ns runbld.scm
   (:require
    [clj-git.core :as git]
+   [clj-time.core :as t]
    [clojure.java.io :as jio]
    [environ.core :as environ]
    [runbld.io :as io]
@@ -26,6 +27,10 @@
   [local commit]
   (let [repo (git/load-repo local)]
     (io/log "Fetching provided commit" commit)
+    (when (git/shallow-clone? repo)
+      (io/log "Repo was shallow.  Fetching all commits newer than 6 months.")
+      (git/git-fetch repo [(str "--shallow-since="
+                                (str (t/minus (t/now) (t/months 6))))]))
     (git/git-checkout repo commit)
     (io/log "Done fetching.")))
 

--- a/src/clj/runbld/tests.clj
+++ b/src/clj/runbld/tests.clj
@@ -1,5 +1,8 @@
 (ns runbld.tests
-  (:require [runbld.tests.junit]))
+  (:require
+   [runbld.schema :refer :all]
+   [runbld.tests.junit]
+   [schema.core :as s]))
 
 (defn capture-failures [workspace]
   (runbld.tests.junit/find-failures workspace))
@@ -16,3 +19,9 @@
       {:report-has-tests true
        :report summary}
       {:report-has-tests false})))
+
+(s/defn add-test-report :- {:test-report TestReport
+                            s/Keyword s/Any}
+  [opts :- {:process OptsProcess
+            s/Keyword s/Any}]
+  (assoc opts :test-report (report (-> opts :process :cwd))))

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -23,7 +23,7 @@ profiles:
         clone: true
         url: https://github.com/elastic/elasticsearch.git
         branch: master
-        depth: 1
+        depth: 2
         wipe-workspace: true
         # Git should ignore reference repos that aren't accessible.
         reference-repo: /some/fake/path

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -303,8 +303,9 @@
                     depth (-> opts :scm :depth)
                     repo (load-repo workspace)]
                 (is (= branch (git-branch repo)))
-                (is (= depth (count (git-log repo))))
-                (reset! master-commit (first (git-log repo))))
+                (let [log (git-log repo)]
+                  (is (= depth (count (git-log repo))))
+                  (reset! master-commit (last log))))
               (testing "scm doesn't break anything else"
                 (is (= 1 (:exit-code res)))
                 (is (= 1 (-> (store/get (-> opts :es :conn)

--- a/test/runbld/test/scm_test.clj
+++ b/test/runbld/test/scm_test.clj
@@ -9,8 +9,6 @@
                     :build {:branch job-branch}})))
 
 (deftest branch-selection
-  {:scm {:branch "1.6"}
-   :build {:branch "3.2"}}
   (testing "Branch selection chooses the right option."
     (is (= {:branch "1.6" :commit nil}
            (test-choose-branch nil "1.6" "3.2"))

--- a/test/runbld/test/scm_test.clj
+++ b/test/runbld/test/scm_test.clj
@@ -1,0 +1,49 @@
+(ns runbld.test.scm-test
+  (:require [clojure.test :refer :all]
+            [environ.core :as environ]
+            [runbld.scm :refer :all]))
+
+(defn test-choose-branch [env-branch scm-branch job-branch]
+  (with-redefs [environ/env {:branch-specifier env-branch}]
+    (choose-branch {:scm {:branch scm-branch}
+                    :build {:branch job-branch}})))
+
+(deftest branch-selection
+  {:scm {:branch "1.6"}
+   :build {:branch "3.2"}}
+  (testing "Branch selection chooses the right option."
+    (is (= {:branch "1.6" :commit nil}
+           (test-choose-branch nil "1.6" "3.2"))
+        "env is nil, should be ignored")
+    (is (= {:branch "1.6" :commit nil}
+           (test-choose-branch "" "1.6" "3.2"))
+        "env is '', should be ignored")
+    (is (= {:branch "1.6" :commit nil}
+           (test-choose-branch "refs/heads/3.2" "1.6" "3.2"))
+        "env and build are the 'same', should choose scm")
+    (is (= {:branch "6.4" :commit nil}
+           (test-choose-branch "6.4" "1.6" "3.2"))
+        "env and build are different, should choose env"))
+  (testing "Branch selection can handle commits."
+    (is (= {:commit "026aac0" :branch "1.6"}
+           (test-choose-branch "026aac0" "1.6" "3.2"))
+        "Commits are supported")
+    (is (= {:commit "026aac0" :branch "3.2"}
+           (test-choose-branch nil "026aac0" "3.2"))
+        "Commits are supported, even when not in the env")
+    (is (= {:commit "abc1234" :branch "3.2"}
+           (test-choose-branch "abc1234" "026aac0" "3.2"))
+        "The first of multiple commits will be chosen.")
+    ;; I don't know what would lead to this, but if its commits all
+    ;; the way down, choose the first and assume we're working with
+    ;; master
+    (is (= {:commit "abc1234" :branch "master"}
+           (test-choose-branch "abc1234" "026aac0" "def5678"))
+        "Use master if no branches are found")
+    (testing "A commit is ignored if it's preceded by a branch"
+      (is (with-redefs [environ/env {:branch-specifier "6.4"}]
+            (= {:branch "6.4" :commit nil}
+               (test-choose-branch "6.4" "026aac0" "3.2"))))
+      (is (with-redefs [environ/env {}]
+            (= {:branch "1.6" :commit nil}
+               (test-choose-branch nil "1.6" "026aac0")))))))

--- a/test/runbld/test/scm_test.clj
+++ b/test/runbld/test/scm_test.clj
@@ -41,9 +41,7 @@
            (test-choose-branch "abc1234" "026aac0" "def5678"))
         "Use master if no branches are found")
     (testing "A commit is ignored if it's preceded by a branch"
-      (is (with-redefs [environ/env {:branch-specifier "6.4"}]
-            (= {:branch "6.4" :commit nil}
-               (test-choose-branch "6.4" "026aac0" "3.2"))))
-      (is (with-redefs [environ/env {}]
-            (= {:branch "1.6" :commit nil}
-               (test-choose-branch nil "1.6" "026aac0")))))))
+      (is (= {:branch "6.4" :commit nil}
+             (test-choose-branch "6.4" "026aac0" "3.2")))
+      (is (= {:branch "1.6" :commit nil}
+             (test-choose-branch nil "1.6" "026aac0"))))))


### PR DESCRIPTION
This adds the ability to specify the branch or commit to checkout based on an environment variable.  

Currently the variable is hard-coded to `branch_specifier` though it could be made configurable in the future.

With this there are now 3 ways to specify the branch- ```env, scm config, and job name```.  Under certain circumstances they will interact.  For instance, if a commit is specified in the environment, runbld will first checkout the branch specified in scm (or build, if no scm branch was provided) and then checkout the commit.

Shallow clones are also tricky because we may not have the commit in the local clone.  In an effort to fetch the commit (but not ```--unshallow``` the whole repo) I added some code to fetch the past 6 months worth of commits.  I wen't back and forth on it and finally just had to pick something.  I am happy to hear feedback.