### PR TITLE
Don't add the html part if no html content is provided

### DIFF
--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -77,9 +77,10 @@
          [:alternative]
          attachments
          [{:type "text/plain; charset=utf-8"
-           :content plain}
-          {:type "text/html; charset=utf-8"
-           :content html}])]
+           :content plain}]
+         (when-not (empty? html)
+           [{:type "text/html; charset=utf-8"
+             :content html}]))]
     (mail/send-message
      conn
      {:from from


### PR DESCRIPTION
Tested locally as it takes a valid smtp server + user + password to get to the NPE caused by the nil html content.