### PR TITLE
Fetch before checking out last good commit

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -146,18 +146,17 @@
     (let [b (find-build opts (-> opts :build :last-success :id))
           commit (-> b :vcs :commit-short)]
       ((:logger opts)
-       "using last successful commit"
-       commit
-       "from"
-       (-> b :build :job-name) (-> b :id)
-       (-> b :process :time-start)
-       (date/human-duration
-        (date/iso-diff-secs
-         (date/from-iso
-          ;; notify on time-end because it makes more
-          ;; logical sense to report on the last
-          ;; completed build's end time, I think
-          (-> b :process :time-end))
-         (date/now)))
+       "Using last successful commit" commit
+       "from the job" (-> b :build :job-name)
+       "with the build id" (-> b :id)
+       "that was started at" (-> b :process :time-start)
+       "and finished" (date/human-duration
+                       (date/iso-diff-secs
+                        (date/from-iso
+                         ;; notify on time-end because it makes more
+                         ;; logical sense to report on the last
+                         ;; completed build's end time, I think
+                         (-> b :process :time-end))
+                        (date/now)))
        "ago")))
   opts)

--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -109,6 +109,7 @@
        ;; only actually check out as working copy if the command line
        ;; opt has been supplied
        (when check-out?
+         (runbld.vcs/fetch-latest vcs-repo)
          (runbld.vcs/check-out vcs-repo (-> build :vcs :commit-id)))
        build)
      check-out?]))

--- a/src/clj/runbld/vcs.clj
+++ b/src/clj/runbld/vcs.clj
@@ -3,5 +3,6 @@
 (defprotocol VcsRepo
   (log-latest [_] "Log map for latest commit")
   (check-out [_ commit] "Set working copy to version at commit")
+  (fetch-latest [_] "Updates local checkout to latest version")
   (provider [_] "What kind of VCS?"))
 

--- a/src/clj/runbld/vcs/git.clj
+++ b/src/clj/runbld/vcs/git.clj
@@ -134,6 +134,11 @@
       (when-let [u (commit-url this commit-id)]
         {:commit-url u})))))
 
+(defn fetch-latest [this]
+  (let [repo (git/load-repo (.dir this))]
+    (git/git-fetch repo)
+    (git/git-checkout repo "HEAD")))
+
 ;; Assume GitHub for now...
 (s/defrecord GitRepo
     [dir     :- s/Str  ;; local working copy
@@ -145,7 +150,8 @@
   VcsRepo
   {:log-latest log-latest
    :provider (constantly provider)
-   :check-out checkout-commit})
+   :check-out checkout-commit
+   :fetch-latest fetch-latest})
 
 (s/defn make-repo :- GitRepo
   [dir org project branch]


### PR DESCRIPTION
Quoting from a comment in the test:
```
The setup is when the last-good-commit is a commit "in the
future" from the point of view of the locally checked-out copy
of the repo.  In that case we get an exception with "fatal:
reference is not a tree" when we attempt to checkout the l-g-c
Simply fetching will resolve the issue.
```