### PR TITLE
Debug email

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -6,6 +6,7 @@
             [runbld.util.data :refer [deep-merge-with deep-merge]]
             [runbld.util.date :as date]
             [runbld.scheduler :as scheduler]
+            [runbld.util.debug :as debug]
             [runbld.vcs.middleware :as vcs]
             [schema.core :as s]
             [slingshot.slingshot :refer [throw+]]))
@@ -106,6 +107,7 @@
                    (:job-name opts))
         vcs-repo (vcs/make-repo opts)]
     [(when-let [build (last-good-build job-name opts vcs-repo)]
+       (debug/log "Found last-good-commit:" (-> build :vcs :commit-id))
        ;; only actually check out as working copy if the command line
        ;; opt has been supplied
        (when check-out?

--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -126,10 +126,14 @@
   [opts :- {:job-name s/Str
             :scheduler (s/protocol scheduler/Scheduler)
             s/Keyword s/Any}]
-  (assoc opts
-         :id (make-id)
-         :build (merge (split-job-name (:job-name opts))
-                       (scheduler/as-map (:scheduler opts)))))
+  (let [build-id (make-id)
+        build-meta (merge (split-job-name (:job-name opts))
+                          (scheduler/as-map (:scheduler opts)))]
+    (debug/log "Build id:" build-id
+               "Build meta:" build-meta)
+    (assoc opts
+           :id build-id
+           :build build-meta)))
 
 (s/defn add-last-success
   [opts :- OptsWithBuild]

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -16,8 +16,7 @@
             [runbld.system :as system]
             [runbld.tests :as tests]
             [runbld.io :as io]
-            [runbld.pipeline :refer [after around before
-                                     debug-log make-pipeline]]
+            [runbld.pipeline :refer [after around before make-pipeline]]
             [runbld.scm :as scm]
             [runbld.util.date :as date]
             [runbld.vcs.git :refer [checkout-commit]]

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -7,6 +7,7 @@
             [runbld.store :as store]
             [runbld.io :as io]
             [runbld.notifications :as n]
+            [runbld.util.email :as email]
             [runbld.vcs :as vcs]
             [stencil.core :as mustache]))
 
@@ -88,12 +89,6 @@
       :subject subject
       :body body})))
 
-(s/defn obfuscate-addr :- s/Str
-  [addr :- s/Str]
-  (str/replace addr
-               (re-pattern "(.*?)@([^.]+\\.)?(.)[^.]+\\.([^.]+)$")
-               "$1@$3***.$4"))
-
 (s/defn render :- s/Str
   [tmpl :- s/Str
    ctx :- EmailCtx]
@@ -110,7 +105,7 @@
              (into (sorted-map) ctx))))
   (let [rcpts (split-addr (-> opts :email :to))]
     ((opts :logger) "MAILING:" (str/join ", "
-                                         (map obfuscate-addr rcpts)))
+                                         (map email/obfuscate-addr rcpts)))
     (let [out (with-out-str
                 (clojure.pprint/pprint
                  (send* (opts :email)

--- a/src/clj/runbld/util/debug.clj
+++ b/src/clj/runbld/util/debug.clj
@@ -1,0 +1,79 @@
+(ns runbld.util.debug
+  "The intent behind this debug ns is to provide a globally accessible
+  logging function (i.e. one that doesn't rely on any state passed
+  in).  So while this may appear to be gross b/c of the essentially
+  global state that it maintains, it was done deliberately to prevent
+  having to thread that state into all corners of the codebase."
+  (:require [clojure.stacktrace :as stacktrace]
+            [clojure.string :as string]
+            [runbld.io :as io]
+            [postal.core :as mail]
+            [runbld.util.email :as email]
+            [slingshot.slingshot :refer [try+ throw+]])
+  (:import (java.util Date)))
+
+(def debug-log
+  "The log is basically a vector of stuff that will eventually be
+  coerced into a string and emailed."
+  (atom []))
+
+(defn reset
+  "Reset the debug-log internal state.  Mostly this is used in tests."
+  []
+  (reset! debug-log []))
+
+(defn get-log []
+  @debug-log)
+
+(defn print-log []
+  (doseq [l @debug-log]
+    (println l)))
+
+(defn log* [ns form-meta & more]
+  (let [[throwable msgs] (if (instance? Throwable (first more))
+                           [(first more) (rest more)]
+                           [nil more])]
+    (swap! debug-log conj
+           (format "[%s] [%s %s:%s] %s%s"
+                   (Date.)
+                   ns
+                   (:line form-meta "")
+                   (:column form-meta "")
+                   (apply print-str msgs)
+                   (if throwable
+                     (str "\n" (with-out-str (stacktrace/print-cause-trace throwable)))
+                     "")))))
+
+(defmacro log
+  "Appends the message and throwable to the debug log, for output if
+  an error occurs"
+  {:arglists '([log-msg]
+               [throwable log-msg]
+               [log-msg & more-msgs]
+               [throwable log-msg & more-msgs])}
+  [& args]
+  `(log* ~*ns* ~(meta &form) ~@args))
+
+(defn send-log [{{:keys [to]} :debug
+                 {:keys [from] :as email-cfg} :email
+                 :keys [job-name]
+                 :as opts}]
+  (when to
+    (io/log "Sending debug log to" (email/obfuscate-addr to))
+    (mail/send-message
+     email-cfg
+     {:from from
+      :to to
+      :subject (str "runbld debug log for " job-name)
+      :body {:type "text/plain; charset=utf-8"
+             :content (string/join "\n" @debug-log)}})))
+
+(defn with-debug-logging [proc opts]
+  (try+
+   (proc opts)
+   (catch Object o
+     (let [t (:throwable &throw-context)]
+       (log t "Error caught in debug logger.")
+       (when (-> opts :debug :to)
+         (send-log opts))
+       (throw+ t)))))

--- a/src/clj/runbld/util/email.clj
+++ b/src/clj/runbld/util/email.clj
@@ -1,0 +1,9 @@
+(ns runbld.util.email
+  (:require [clojure.string :as str]
+            [schema.core :as s]))
+
+(s/defn obfuscate-addr :- s/Str
+  [addr :- s/Str]
+  (str/replace addr
+               (re-pattern "(.*?)@([^.]+\\.)?(.)[^.]+\\.([^.]+)$")
+               "$1@$3***.$4"))

--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -4,6 +4,7 @@
             [slingshot.slingshot :refer [throw+]])
   (:require [clojure.java.io :as io]
             [environ.core :as environ]
+            [runbld.util.debug :as debug]
             [runbld.vcs :as vcs]
             [runbld.vcs.subversion :as svn]
             [runbld.vcs.git :as git]))
@@ -26,13 +27,21 @@
                               (get-in opts [:build :project])
                               (get-in opts [:env :SVN_REVISION]))
 
-      :else (throw+
-             {:error ::unknown-repo
-              :msg (format (str
-                            "%s: unknown repository type "
-                            "(only know about git and svn currently)")
-                           cwd)
-              :opts opts}))))
+      :else
+      (let [msg (str cwd ": unknown repository type "
+                     "(only know about git and svn currently)")
+            f (io/file cwd)
+            exists? (.exists f)]
+        (debug/log msg
+                   "CWD exists?" exists?
+                   "Listing:" (if exists?
+                                (.list f)
+                                "N/A")
+                   "Process opts:" (:process opts))
+        (throw+
+         {:error ::unknown-repo
+          :msg msg
+          :opts opts})))))
 
 (s/defn add-vcs-info
   [opts :- OptsWithBuild]

--- a/test/config/debug.yml
+++ b/test/config/debug.yml
@@ -1,0 +1,21 @@
+es:
+  build-index: runbld-build
+  failure-index: runbld-failure
+  log-index: runbld-log
+
+process:
+  env:
+    RUNBLD_TEST: RUNBLD_TEST
+
+email:
+  host: smtp.example.com
+  port: 587
+  user: smtpuser
+  pass: pass!
+  from: default@example.com
+  to: default@example.com
+  template-txt: templates/email.mustache.txt
+  template-html: templates/email.mustache.html
+
+debug:
+  to: default@example.com

--- a/test/runbld/test/email_test.clj
+++ b/test/runbld/test/email_test.clj
@@ -8,6 +8,7 @@
             [runbld.opts :as opts]
             [runbld.store :as store]
             [runbld.test.support :as ts]
+            [runbld.util.email :as email-util]
             [runbld.vcs.git :as git]
             [schema.test]
             [stencil.core :as mustache]))
@@ -37,11 +38,11 @@
 
 (deftest obfuscation
   (is (= "foo@b***.dom"
-         (email/obfuscate-addr "foo@bar.dom")))
+         (email-util/obfuscate-addr "foo@bar.dom")))
   (is (= "foo@b***.dom"
-         (email/obfuscate-addr "foo@bar.baz.dom")))
+         (email-util/obfuscate-addr "foo@bar.baz.dom")))
   (is (= "foo@q***.dom"
-         (email/obfuscate-addr "foo@bar.quux.dom"))))
+         (email-util/obfuscate-addr "foo@bar.quux.dom"))))
 
 (defn find-contents [body]
   (->> body

--- a/test/runbld/test/support.clj
+++ b/test/runbld/test/support.clj
@@ -1,7 +1,8 @@
 (ns runbld.test.support
   (:require
    [runbld.io :as io]
-   [runbld.util.date :as date]))
+   [runbld.util.date :as date]
+   [runbld.util.debug :as debug]))
 
 (defn test-log [& x]
   (io/spit (.getAbsolutePath (clojure.java.io/file "test.log"))
@@ -16,3 +17,9 @@
   ;; Don't pollute the console
   (with-redefs [io/log test-log]
     (f)))
+
+(defn reset-debug-log-fixture
+  "Clears out the debug log between tests."
+  [f]
+  (debug/reset)
+  (f))


### PR DESCRIPTION
This adds a new type of log to runbld that can be sent to a smaller audience specifically for debugging runbld.  Runbld failures are often the result of not taking into account the many odd states that the repo or workspace can be in.  In those cases it's difficult to reproduce errors b/c the state cannot be reproduced and all knowledge of that state may be inaccessible or lost.  Adding all of the necessary debugging information to the build output might be, depending on the build, either too noisy or lost in the vast amount of build output.

The debug log will only be sent in the case of an error.

Resolves #92 