### PR TITLE
Override the current vcs info with the last-good-build's info

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -139,11 +139,14 @@
   [opts :- OptsWithBuild]
   (let [[last-good-build checked-out?]
         (maybe-find-last-good-build-and-checkout opts)]
-    (update
-     opts :build merge (when last-good-build
-                         {:last-success
-                          (abbreviate-last-good-build
-                           last-good-build checked-out?)}))))
+    (cond-> opts
+      last-good-build
+      (update :build merge {:last-success (abbreviate-last-good-build
+                                           last-good-build checked-out?)})
+
+      (and last-good-build checked-out?)
+      (update :vcs merge
+              (:vcs (find-build opts (:id last-good-build)))))))
 
 (s/defn maybe-log-last-success
   [opts :- (merge {:logger clojure.lang.IFn}

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -253,7 +253,8 @@
               (git second-repo "push")
               ;; Run runbld on the second clone to store the l-g-c as
               ;; one that doesn't exist in the first
-              (let [[opts-second res-second]
+              (let [second-commit (:commit (git/head-commit second-repo))
+                    [opts-second res-second]
                     (run (conj
                           ["-c" "test/config/main.yml"
                            "-j" "elastic+foo+master+intake"
@@ -261,6 +262,7 @@
                           (if (opts/windows?)
                             "test/success.bat"
                             "test/success.bash")))
+                    _ (reset! email-body "no-email-body-yet")
                     ;; now run it on the first clone, which would
                     ;; throw an exception were it not for the added
                     ;; fetching
@@ -276,7 +278,8 @@
                 ;; make sure we saw what we expected to see
                 (is (= 0 (:exit-code res-second)))
                 (is (= 1 (:exit-code res-first)))
-                (is (.contains @email-body "using successful commit")
+                (is (.contains @email-body
+                               (str "using successful commit " second-commit))
                     (with-out-str
                       (println "@email-body")
                       (prn @email-body)))))


### PR DESCRIPTION
By the time this code runs we have already looked up the
last-good-commit and checked it out from vcs.  This change propagates
the new vcs info forward to notifications.

Resolves #98 