### PR TITLE
Add repro lines to email summary

### DIFF
--- a/src/clj/runbld/results.clj
+++ b/src/clj/runbld/results.clj
@@ -2,6 +2,6 @@
   (:require [runbld.results.gradle :as gradle]))
 
 (defn summary [conn idx build-id]
-  (when-let [s (gradle/went-wrong conn idx build-id)]
+  (when-let [s (gradle/summary conn idx build-id)]
     {:summary s
      :lines (gradle/failure-lines conn idx build-id)}))


### PR DESCRIPTION
This will add lines from ES test suite matching `REPRODUCE WITH` to emails. Truncates to 10.

```
> There were test failures: 2 suites, 696 tests, 9 errors, 216 failures, 65 ignored (65 assumptions) [seed: 3E80C31916A0ABA2]

REPRODUCE WITH: gradle :qa:mixed-cluster:v5.6.0-SNAPSHOT#mixedClusterTestRunner \
  -Dtests.seed=3E80C31916A0ABA2 \
  -Dtests.class=org.elasticsearch.backwards.MixedClusterClientYamlTestSuiteIT \
  -Dtests.method="test {p0=cluster.state/20_filtering/Filtering the cluster state by indices using wildcards should work in routing table and metadata}" \
  -Dtests.security.manager=true \
  -Dtests.locale=es-EC \
  -Dtests.timezone=GMT0
```