### PR TITLE
Build metadata

### DIFF
--- a/src/clj/runbld/io.clj
+++ b/src/clj/runbld/io.clj
@@ -200,3 +200,18 @@
     f2 :- java.io.File]
    (= (abspath-file f1)
       (abspath-file f2))))
+
+(defn find-files
+  [dir regex]
+  (when dir
+    (let [dir (jio/file dir)]
+      (when (.exists dir)
+        (->> (file-seq dir)
+             (filter #(.isFile %))
+             (map #(.getCanonicalPath %))
+             (map str)
+             (filter #(re-find regex %))
+             (map jio/file)
+             (remove #(= 0 (.length %)))
+             (map #(.toURI %))
+             (map #(.toURL %)))))))

--- a/src/clj/runbld/main.clj
+++ b/src/clj/runbld/main.clj
@@ -70,7 +70,7 @@
    (around debug/with-debug-logging)
    (before java/add-java)
    (before scheduler/add-scheduler)
-   (before build/add-build-meta)
+   (before build/add-build-info)
    (before store/store-result) ;; store that we started
    (before scm/wipe-workspace)
    (before scm/bootstrap-workspace)
@@ -82,6 +82,7 @@
    (after  email/send-email)
    (after  store/store-result) ;; store that we finished
    (after  tests/add-test-report)
+   (around build/add-build-meta)
    (around log-script-execution)])
 
 ;; -main :: IO ()

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -167,6 +167,7 @@
    :scheduler                  s/Str
    :url                        s/Str
    :console-url                s/Str
+   (s/optional-key :metadata)  s/Str
    :tags                       [s/Str]
    (s/optional-key :number)    s/Str
    (s/optional-key :executor)  s/Str
@@ -321,6 +322,7 @@
                :number              m/keyword
                :executor            m/keyword
                :node                m/keyword
+               :metadata            m/multi-string
                :last-success
                {:properties
                 {:id                m/keyword

--- a/test/add-metadata.bash
+++ b/test/add-metadata.bash
@@ -1,0 +1,8 @@
+exec > /dev/null 2>&1
+
+echo "the first metadata;" > build_metadata-number-1
+
+mkdir subdir
+echo "the second metadata;" > build_metadata-number-2
+
+exit 0

--- a/test/check-metadata.bash
+++ b/test/check-metadata.bash
@@ -1,0 +1,7 @@
+exec > /dev/null 2>&1
+
+if [ "$BUILD_METADATA" = "the first metadata;the second metadata;" ]; then
+    exit 0;
+else
+    exit 1
+fi

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -28,11 +28,11 @@ profiles:
         # Git should ignore reference repos that aren't accessible.
         reference-repo: /some/fake/path
 
-  - '^elastic\+foo\+5\.x$':
+  - '^elastic\+foo\+6\.0$':
       scm:
         clone: true
         url: https://github.com/elastic/elasticsearch.git
-        branch: 5.x
+        branch: '6.0'
         depth: 1
         wipe-workspace: true
         # Git should ignore reference repos that aren't accessible.

--- a/test/runbld/test/email_test.clj
+++ b/test/runbld/test/email_test.clj
@@ -159,7 +159,7 @@
         out (java.io.StringWriter.)]
     (with-redefs [mail/send-message (fn [conn msg]
                                       (reset! email msg))]
-      (git/with-tmp-repo [d "tmp/git/email-log"]
+      (git/with-tmp-repo [d "tmp/git/email-reply-to"]
         (binding [*out* out
                   *err* out]
           (run (conj ["-c" "test/config/main.yml"

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -310,7 +310,7 @@
                              (assoc :logger runbld.io/log)
                              ;; make schema happy
                              (assoc :scheduler (default-sched/make {})))
-                opts (build/add-build-meta raw-opts)]
+                opts (build/add-build-info raw-opts)]
             (scm/bootstrap-workspace
              (assoc-in opts [:scm :wipe-workspace] false))
             (is (= "master"
@@ -329,7 +329,7 @@
                                (assoc :logger runbld.io/log)
                                ;; make schema happy
                                (assoc :scheduler (default-sched/make {})))
-                  opts (build/add-build-meta raw-opts)]
+                  opts (build/add-build-info raw-opts)]
               (scm/bootstrap-workspace
                (assoc-in opts [:scm :wipe-workspace] false))
               (is (nil? (-> opts :scm :branch)))

--- a/test/runbld/test/main_test.clj
+++ b/test/runbld/test/main_test.clj
@@ -374,7 +374,7 @@
                 (let [log (git-log repo)]
                   (is (= depth (count (git-log repo))))
                   (reset! master-commit (last log)))
-                (is (shallow-clone? repo))                )
+                (is (shallow-clone? repo)))
               (testing "scm doesn't break anything else"
                 (is (= 1 (:exit-code res)))
                 (is (= 1 (-> (store/get (-> opts :es :conn)
@@ -384,13 +384,13 @@
                              :process
                              :exit-code)))
                 (is (.startsWith
-                     (let [[_ _ _ subj _ _] @email] subj) "FAILURE"))
+                     (let [[_ _ _ _ subj _ _] @email] subj) "FAILURE"))
                 (is (.contains (slack-msg) "FAILURE")))
               (testing "Running again w/o wipe-workspace should update the repo"
                 (let [[opts2 res2] (run
                                      (conj
                                       ["-c" "test/config/scm.yml"
-                                       "-j" "elastic+foo+5.x"
+                                       "-j" "elastic+foo+6.0"
                                        "-d" workspace]
                                       (if (opts/windows?)
                                         "test/fail.bat"


### PR DESCRIPTION
This change allows the wrapped scripts to produce files that start with `build_metadata`.  These files will be concatenated and stored in ES.  On subsequent executions for the same job, the metadata stored in ES will be put into a new environment variable, `BUILD_METADATA`