### PR TITLE
Email improvements

### DIFF
--- a/resources/templates/email.mustache.html
+++ b/resources/templates/email.mustache.html
@@ -47,7 +47,7 @@ happened.</em>
 
 <table>
 <tr><td><code>Build</code></td><td><code>{{ id }}</code></td></tr>
-<tr><td><code>Log</code></td><td><code>{{ build.console-url }}</code></td></tr>
+<tr><td><code>Log</code></td><td><code><a href="{{ build.console-url }}">{{ build.console-url }}</a></code></td></tr>
 <tr><td><code>Duration</code></td><td><code>{{ process.took-human }} ({{ process.took }}ms)</code></td></tr>
 <tr><td><code>Started</code></td><td><code>{{ process.time-start }}</code></td></tr>
 <tr><td><code>Ended</code></td><td><code>{{ process.time-end }}</code></td></tr>

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -72,17 +72,18 @@
    html     :- (s/maybe s/Str)
    attachments :- [s/Any]]
   (let [body
-        ;; With multipart/alternative, the earlier the part, the lower
-        ;; the priority, so place attachments first, plain text next,
-        ;; and the HTML last
         (concat
-         [:alternative]
-         attachments
-         [{:type "text/plain; charset=utf-8"
-           :content plain}]
-         (when-not (empty? html)
-           [{:type "text/html; charset=utf-8"
-             :content html}]))]
+         [:mixed
+          (concat
+           [:alternative]
+           ;; With multipart/alternative, the earlier the part, the lower
+           ;; the priority, so place plain text first and the HTML last
+           [{:type "text/plain; charset=utf-8"
+             :content plain}]
+           (when-not (empty? html)
+             [{:type "text/html; charset=utf-8"
+               :content html}]))]
+         attachments)]
     (mail/send-message
      conn
      {:from from

--- a/test/runbld/test/email_test.clj
+++ b/test/runbld/test/email_test.clj
@@ -45,7 +45,7 @@
          (email-util/obfuscate-addr "foo@bar.quux.dom"))))
 
 (defn find-contents [body]
-  (->> body
+  (->> (tree-seq sequential? identity body)
        (filter #(and (map? %) (not (= :attachment (:type %)))))
        (map :content)))
 
@@ -111,7 +111,7 @@
                 (is (= 2 (count contents)) body)
                 (doseq [content contents]
                   (is (.contains content "Cannot expand ZIP")))
-                (is (= 3 (count body))
+                (is (= 2 (count body))
                     (pr-str @email)))))
           (testing "with gradle task"
             (let [out (java.io.StringWriter.)
@@ -132,7 +132,7 @@
                 (is (= 2 (count contents)) body)
                 (doseq [content contents]
                   (is (.contains content ":core:integTest")))
-                (is (= 4 (count body))
+                (is (= 3 (count body))
                     (pr-str @email))))))))))
 
 (deftest reproduce-with


### PR DESCRIPTION
2 fixes here:
- one is simply making a link clickable in the email template.  
- the other is to properly format the email such that Thunderbird will render the attachments (see the commit message for 8494464)