### PR TITLE
Basedir for scm

### DIFF
--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -93,6 +93,7 @@
    :url s/Str
    (s/optional-key :reference-repo) s/Str
    (s/optional-key :branch) s/Str
+   (s/optional-key :basedir) s/Str
    :wipe-workspace s/Bool
    (s/optional-key :depth) s/Int})
 

--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -3,11 +3,13 @@
    [clj-git.core :as git]
    [clj-time.core :as t]
    [clojure.java.io :as jio]
+   [clojure.string :as string]
    [environ.core :as environ]
    [runbld.io :as io]
    [runbld.schema :refer :all]
    [schema.core :as s]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [clojure.string :as string]))
 
 (defn find-workspace
   "just to override in tests"
@@ -109,6 +111,12 @@
           branch (first (drop-while commit? branches))]
       {:commit commit :branch (or branch "master")})))
 
+(defn checkout-dir [opts]
+  (let [cwd (-> opts :process :cwd)]
+    (if-let [basedir (-> opts :scm :basedir)]
+      (string/replace (str cwd "/" basedir) #"/+" "/")
+      cwd)))
+
 (s/defn bootstrap-workspace
   "Prepare the local workspace by cloning or updating the repository,
   as necessary."
@@ -117,7 +125,7 @@
             (s/optional-key :scm) OptsScm
             s/Keyword s/Any}]
   (let [clone? (boolean (-> opts :scm :clone))
-        local (-> opts :process :cwd)
+        local (checkout-dir opts)
         remote (-> opts :scm :url)
         reference (-> opts :scm :reference-repo)
         {:keys [branch commit]} (choose-branch opts)

--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -114,7 +114,7 @@
 (defn checkout-dir [opts]
   (let [cwd (-> opts :process :cwd)]
     (if-let [basedir (-> opts :scm :basedir)]
-      (string/replace (str cwd "/" basedir) #"/+" "/")
+      (string/replace (string/join "/" [cwd basedir]) #"/+" "/")
       cwd)))
 
 (s/defn bootstrap-workspace

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -66,4 +66,4 @@ profiles:
         wipe-workspace: true
         # Git should ignore reference repos that aren't accessible.
         reference-repo: /some/fake/path
-        basedir: /some/other/dir
+        basedir: some/other/dir

--- a/test/config/scm.yml
+++ b/test/config/scm.yml
@@ -56,3 +56,14 @@ profiles:
         wipe-workspace: true
         # Git should ignore reference repos that aren't accessible.
         reference-repo: /some/fake/path
+
+  - '^base\+dir\+master':
+      scm:
+        clone: true
+        url: https://github.com/elastic/elasticsearch.git
+        branch: master
+        depth: 1
+        wipe-workspace: true
+        # Git should ignore reference repos that aren't accessible.
+        reference-repo: /some/fake/path
+        basedir: /some/other/dir


### PR DESCRIPTION
Adds a config value to the scm config to allow git clones to occur in a subdirectory relative to the cwd of the script.

Fixes #115