### PR TITLE
Use basedir as cwd

### DIFF
--- a/src/clj/runbld/scm.clj
+++ b/src/clj/runbld/scm.clj
@@ -114,12 +114,6 @@
       (string/replace #"^refs/heads/" "")
       (string/replace #"^origin/" "")))
 
-(defn checkout-dir [opts]
-  (let [cwd (-> opts :process :cwd)]
-    (if-let [basedir (-> opts :scm :basedir)]
-      (string/replace (string/join "/" [cwd basedir]) #"/+" "/")
-      cwd)))
-
 (s/defn bootstrap-workspace
   "Prepare the local workspace by cloning or updating the repository,
   as necessary."
@@ -128,7 +122,7 @@
             (s/optional-key :scm) OptsScm
             s/Keyword s/Any}]
   (let [clone? (boolean (-> opts :scm :clone))
-        local (checkout-dir opts)
+        local (-> opts :process :cwd)
         remote (-> opts :scm :url)
         reference (-> opts :scm :reference-repo)
         {:keys [branch commit]} (choose-branch opts)

--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -13,7 +13,7 @@
 
 (s/defn make-repo :- (s/protocol vcs/VcsRepo)
   [opts]
-  (let [source-dir (scm/checkout-dir opts)]
+  (let [source-dir (get-in opts [:process :cwd])]
     (cond
       (.isDirectory
        (io/file source-dir ".git")) (git/make-repo

--- a/test/check-cwd.bash
+++ b/test/check-cwd.bash
@@ -1,0 +1,11 @@
+exec > /dev/null 2>&1
+
+# see if the current directory ends with the path that was passed in
+pwd | grep "/some/other/dir$"
+if [ $? -eq 0 ]; then
+    exit 0
+else
+    # probably not a problem to return whatever grep returns, but just
+    # in case, munge all failures into 1
+    exit 1
+fi

--- a/test/runbld/test_support.clj
+++ b/test/runbld/test_support.clj
@@ -7,7 +7,10 @@
    [runbld.util.debug :as debug])
   (:import (java.io FileOutputStream)))
 
-(def log-file (clojure.java.io/file "target" "test.log"))
+(def log-file (clojure.java.io/file
+               (System/getProperty "user.dir")
+               "target"
+               "test.log"))
 
 (defn test-log [& x]
   (io/spit (.getAbsolutePath log-file)


### PR DESCRIPTION
This changes the behavior of the basedir config to also change the cwd for the wrapped script mainly because that is what Jenkins does.  The `-d` cli option to set the cwd will take precedence, though, if a different cwd is needed.