### PR TITLE
Parse gpg signature without header

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,7 @@
 * runbld changes
+** 1.5.5
+   - Parse git commits that are GPG-signed, but the signature doesn't include
+     header information.
 ** 1.5.4
    - Search for =build_metadata= files in the root execution directory
      (Java's =user.dir=) rather than from the wrapped script's

--- a/src/clj/clj_git/core.clj
+++ b/src/clj/clj_git/core.clj
@@ -175,8 +175,10 @@
 (defn parse-raw-commit [s]
   (let [res (i/transform raw-transforms (parse-log-raw s))]
     (if (instance? instaparse.gll.Failure res)
-      (throw (ex-info "parse failure" {:res res
-                                       :commit s}))
+      (do
+        (println s)
+        (throw (ex-info "parse failure" {:res res
+                                         :commit s})))
       res)))
 
 (defn git-log-commit

--- a/src/clj/clj_git/grammar/raw.bnf
+++ b/src/clj/clj_git/grammar/raw.bnf
@@ -4,8 +4,8 @@ git = commitLine <newline>
       [ parentLine <newline> ]
       authorLine <newline>
       committerLine <newline>
-      [ gpgsig <newline> ]
-      <newline>
+      [ gpgsig ]
+      ( <oneSp>? <newline> )+
       msgTitle
       [ msgBody <newline> ]
       [ <newline> ]
@@ -20,7 +20,7 @@ committerLine = <'committer'> <sp> name? <bracket> emailAddr <bracket> <sp> time
 gpgsig = <'gpgsig'>
          <oneSp> gpgPrefix newline
          ( <oneSp> gpgHeader newline )*
-           <oneSp> newline
+         <oneSp>? newline
          ( <oneSp> gpgData newline )+
          <oneSp> gpgPostfix
 

--- a/test/clj_git/commit-gpg-no-header.txt
+++ b/test/clj_git/commit-gpg-no-header.txt
@@ -1,0 +1,21 @@
+commit 1a0c8e83e292e9ccb99e985232418515581ce16e
+tree b73e35b2638f6478bcd276343a4bd4ab852f270f
+parent 1d76cac9b0527779ee6e75d20d4651cc75429775
+author CJ Cenizal <cj@cenizal.com> 1509152865 -0700
+committer GitHub <noreply@github.com> 1509152865 -0700
+gpgsig -----BEGIN PGP SIGNATURE-----
+ 
+ wsBcBAABCAAQBQJZ89hhCRBK7hj4Ov3rIwAAdHIIAEeGSOwoRX1PMc5zFubZtc/K
+ Hp73SSVcOU0PeFjXiauDC0M7SiAnFsi9Wf5Fr1aRVnwgR1Cjt7ryEh6hTE71zGmX
+ dnqdAGKibKiim4mobUyfyakB9jKkVPRNyHXknCBZF7hse5dFKz5egZ3Enff+IYlI
+ eskCvVHKPWN7cwxcim6mJvJjmbNds41xQk6cJj6jHR5yTf06GhL0u8dbekTNpIV5
+ dTqHnfFxP9qyGCOwp9O0g49dBpXbVTIlIa+cEDqm2hucdNe1vQWK3zAiXJqBnFJh
+ XUBGb4lM2Wn9813DI5PiSWytC481dmHamrIKM/xJ7rjVniKcEAsnBGYgW3XXbRg=
+ =udVh
+ -----END PGP SIGNATURE-----
+ 
+
+    [eslint-config-kibana] Upgrade eslint-config-kibana to 0.13.0 (#2938)
+    
+    * Upgrade eslint-config-kibana to 0.13.0 and autofix linting errors (spacing).
+    * Manual linting fixes.

--- a/test/clj_git/core_test.clj
+++ b/test/clj_git/core_test.clj
@@ -45,7 +45,8 @@
 
 (deftest parse-samples
   (doseq [f (->> ["clj_git/commit.txt"
-                  "clj_git/commit-no-name.txt"]
+                  "clj_git/commit-no-name.txt"
+                  "clj_git/commit-gpg-no-header.txt"]
                  (map io/resource)
                  (map io/file))]
     (testing f

--- a/test/repo/java/no-errors/pom.xml
+++ b/test/repo/java/no-errors/pom.xml
@@ -15,4 +15,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+    </plugins>
+ </build>
 </project>

--- a/test/repo/java/some-errors/pom.xml
+++ b/test/repo/java/some-errors/pom.xml
@@ -15,4 +15,16 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.6</source>
+          <target>1.6</target>
+          <fork>true</fork>
+        </configuration>
+      </plugin>
+    </plugins>
+ </build>
 </project>


### PR DESCRIPTION
We're starting to see commits that have a GPG signature, but contains no header information. This fixes the parser to handle those.