### PR TITLE
make it so first-success takes precedence over success

### DIFF
--- a/src/clj/runbld/notifications/slack.clj
+++ b/src/clj/runbld/notifications/slack.clj
@@ -58,8 +58,9 @@
           (= "FAILURE")))))
 
 (defn send-success? [opts build]
-  (or (-> opts :slack :success)
-      (first-successful-build? opts build)))
+  (if (-> opts :slack :first-success)
+    (first-successful-build? opts build)
+    (-> opts :slack :success)))
 
 (defn send?
   "Determine whether to send a slack alert depending on configs"

--- a/src/clj/runbld/opts.clj
+++ b/src/clj/runbld/opts.clj
@@ -60,7 +60,7 @@
     :disable false}
 
    :slack
-   {:first-success true
+   {:first-success false
     :success true
     :failure true
     :template "templates/slack.mustache.json"

--- a/test/config/slack.yml
+++ b/test/config/slack.yml
@@ -4,7 +4,7 @@ es:
   log-index: runbld-log
 
 slack:
-  success: false
+  first-success: true
 
 process:
   env:

--- a/test/runbld/main_test.clj
+++ b/test/runbld/main_test.clj
@@ -153,15 +153,11 @@
         (reset! email [])
         (reset! slack [])
         (git/with-tmp-repo [d "tmp/git/main-test-5"]
-          (let [args (conj
-                      ["-c" "test/config/slack.yml"
-                       "-j" "elastic+foo+master"
-                       "-d" d]
-                      "test/success.bash")
-                opts (merge (opts/parse-args args)
-                            {:slack
-                             {:success false}})
-                res (apply main/-main args)]
+          (let [[opts res] (run (conj
+                                 ["-c" "test/config/slack.yml"
+                                  "-j" "elastic+foo+master"
+                                  "-d" d]
+                                 "test/success.bash"))]
             (is (empty? @email))
             ;; we should get a slack notification
             (is (.contains (slack-msg) "SUCCESS")))))


### PR DESCRIPTION
The issue was a build that had `first-success` set to `true` but had not set `success` to `false`.  Since `first-success` is more specific I figure it ought to take precedence over just `success`.  

So:

| success  | first-success |  Behavior |
| ------------- | ------------- | -----|
| true  | false  | notification always sent on success |
| false | true | notification only sent on first success after a failure |
| true | true | notification only sent on first success after a failure |
| false | false | notification never sent on success |

To maintain the existing behavior I changed the default of the `first-success` setting to false.