### PR TITLE
Add retries around gathering system facts

### DIFF
--- a/test/runbld/email_test.clj
+++ b/test/runbld/email_test.clj
@@ -14,7 +14,7 @@
    [schema.test]
    [stencil.core :as mustache]))
 
-(use-fixtures :each ts/redirect-logging-fixture)
+(use-fixtures :each (ts/redirect-logging-fixture))
 (use-fixtures :once
   schema.test/validate-schemas
   ts/dont-die-fixture)

--- a/test/runbld/main_test.clj
+++ b/test/runbld/main_test.clj
@@ -49,7 +49,7 @@
   ts/dont-die-fixture)
 
 (use-fixtures :each
-  ts/redirect-logging-fixture
+  (ts/redirect-logging-fixture)
   ts/reset-debug-log-fixture)
 
 (s/deftest main

--- a/test/runbld/opts_test.clj
+++ b/test/runbld/opts_test.clj
@@ -9,7 +9,7 @@
    [schema.test]))
 
 (use-fixtures :once schema.test/validate-schemas)
-(use-fixtures :each ts/redirect-logging-fixture)
+(use-fixtures :each (ts/redirect-logging-fixture))
 
 (deftest basic
   (let [java-home (:home (java/jvm-facts))

--- a/test/runbld/process_test.clj
+++ b/test/runbld/process_test.clj
@@ -12,7 +12,7 @@
    [schema.test]))
 
 (use-fixtures :once schema.test/validate-schemas)
-(use-fixtures :each ts/redirect-logging-fixture)
+(use-fixtures :each (ts/redirect-logging-fixture))
 
 (deftest output-io
   (io/with-tmp-dir [dir ["tmp" (str *ns* "-")]]

--- a/test/runbld/system_test.clj
+++ b/test/runbld/system_test.clj
@@ -1,14 +1,43 @@
 (ns runbld.system-test
   (:require
    [clojure.test :refer :all]
+   [robert.bruce :refer [*try*]]
    [runbld.facts.factory :as facter]
    [runbld.fs.factory :as fs]
    [runbld.system :as system]
+   [runbld.test-support :as ts]
    [schema.test]))
 
-(use-fixtures :once schema.test/validate-schemas)
+(use-fixtures :once
+  schema.test/validate-schemas
+  ts/redirect-logging-fixture)
 
 (deftest basic
   ;; schema does most of the work here, just want to see if it returns
   ;; a map that matches it
   (is (system/inspect-system ".")))
+
+(deftest retries
+  (testing "failures retry then bubble"
+    (let [tries (atom 0)
+          orig-retry system/report-retry]
+      (with-redefs [facter/make-facter (fn []
+                                         (throw (Exception. "test failure")))
+                    system/report-retry (fn [err]
+                                          (swap! tries inc)
+                                          (orig-retry err))]
+        (is (thrown? Exception (system/inspect-system ".")))
+        (is (= 5 @tries)))))
+  (testing "success after retries"
+    (let [tries (atom 0)
+          orig-retry system/report-retry
+          orig-make-facter facter/make-facter]
+      (with-redefs [facter/make-facter (fn []
+                                         (if (<= *try* 3)
+                                           (throw (Exception. "test failure"))
+                                           (orig-make-facter)))
+                    system/report-retry (fn [err]
+                                          (swap! tries inc)
+                                          (orig-retry err))]
+        (is (system/inspect-system "."))
+        (is (= 3 @tries))))))


### PR DESCRIPTION
Occasionally we'll see issues while gathering facts (system and network information).  I suspect they're transient so a quick retry ought to get us unstuck.  Specifically we most recently saw an issue while gathering EC2 metadata.