### PR TITLE
order of metadata should not matter

### DIFF
--- a/test/check-metadata.bash
+++ b/test/check-metadata.bash
@@ -1,7 +1,8 @@
 exec > /dev/null 2>&1
 
-if [ "$BUILD_METADATA" = "the first metadata;the second metadata" ]; then
-    exit 0;
+if [[ "$BUILD_METADATA" =~ ^.*the.first.metadata.*$ &&
+      "$BUILD_METADATA" =~ ^.*the.second.metadata.*$ ]]; then
+    exit 0
 else
     exit 1
 fi

--- a/test/runbld/main_test.clj
+++ b/test/runbld/main_test.clj
@@ -646,14 +646,16 @@
                      "elastic+foo+master+intake"]
                     "test/check-metadata.bash"))]
           (is (= 0 (:exit-code res-intake)))
-          (is (= "the first metadata;the second metadata"
-                 (get-in (store/get
-                          (-> opts-intake :es :conn)
-                          (-> res-intake :store-result :addr :index)
-                          (-> res-intake :store-result :addr :type)
-                          (-> res-intake :store-result :addr :id))
-                         [:build :metadata]))
-              "the metadata should be stored.")
+          (let [stored-metadata (get-in
+                                 (store/get
+                                  (-> opts-intake :es :conn)
+                                  (-> res-intake :store-result :addr :index)
+                                  (-> res-intake :store-result :addr :type)
+                                  (-> res-intake :store-result :addr :id))
+                                 [:build :metadata])]
+            (is (= #{"the first metadata" "the second metadata"}
+                   (set (clojure.string/split stored-metadata #";")))
+                "the metadata should be stored."))
           ;; 0 exit code means the second script got the
           ;; metadata- the check is in the bash script
           (is (= 0 (:exit-code res-periodic))


### PR DESCRIPTION
Had some build failures in the new elastic-runbld-master job: https://infra-ci.elastic.co/job/elastic+runbld+master/3/console

Chatted with @leathekd about them, and found out it's a simple matter of the metadata strings coming in in a different order, which doesn't matter for those tests.

This should make them order-agnostic, and get the build passing again.