### PR TITLE
Fix intermittent issues in AWS node detection on Vagrant

### DIFF
--- a/src/clj/runbld/hosting/aws_ec2.clj
+++ b/src/clj/runbld/hosting/aws_ec2.clj
@@ -27,6 +27,7 @@
                  {:socket-timeout 500 :conn-timeout 500}))
       (catch java.net.SocketTimeoutException _)
       (catch org.apache.http.conn.ConnectTimeoutException _)
+      (catch org.apache.http.conn.NoHttpResponseException _)
       (catch java.net.ConnectException _)
       ;; Non-AWS Windows
       (catch java.net.SocketException _)


### PR DESCRIPTION
When running on Vagrant, runbld fails intermittently while trying to detect an AWS environment. This PR should help with that.

Example of a failed build:
```
00:00:09.937 runbld>>> BUILD: https://5086a1f436ee16623a447bdf25881bbc.us-east-1.aws.found.io:9243/build-1498188341992/t/20171214153418-2BB184FE
00:00:21.849 #error {
00:00:21.849  :cause 169.254.169.254:80 failed to respond
00:00:21.849  :via
00:00:21.849  [{:type org.apache.http.NoHttpResponseException
00:00:21.849    :message 169.254.169.254:80 failed to respond
00:00:21.849    :at [org.apache.http.impl.conn.DefaultHttpResponseParser parseHead DefaultHttpResponseParser.java 141]}]
00:00:21.849  :trace
00:00:21.849  [[org.apache.http.impl.conn.DefaultHttpResponseParser parseHead DefaultHttpResponseParser.java 141]
00:00:21.849   [org.apache.http.impl.conn.DefaultHttpResponseParser parseHead DefaultHttpResponseParser.java 56]
00:00:21.849   [org.apache.http.impl.io.AbstractMessageParser parse AbstractMessageParser.java 259]
00:00:21.849   [org.apache.http.impl.DefaultBHttpClientConnection receiveResponseHeader DefaultBHttpClientConnection.java 163]
00:00:21.849   [org.apache.http.protocol.HttpRequestExecutor doReceiveResponse HttpRequestExecutor.java 273]
00:00:21.849   [org.apache.http.protocol.HttpRequestExecutor execute HttpRequestExecutor.java 125]
00:00:21.849   [org.apache.http.impl.execchain.MainClientExec execute MainClientExec.java 272]
00:00:21.849   [org.apache.http.impl.execchain.ProtocolExec execute ProtocolExec.java 185]
00:00:21.849   [org.apache.http.impl.execchain.RetryExec execute RetryExec.java 89]
00:00:21.849   [org.apache.http.impl.execchain.RedirectExec execute RedirectExec.java 111]
00:00:21.849   [org.apache.http.impl.client.InternalHttpClient doExecute InternalHttpClient.java 185]
00:00:21.849   [org.apache.http.impl.client.CloseableHttpClient execute CloseableHttpClient.java 83]
00:00:21.849   [clj_http.core$request invokeStatic core.clj 412]
00:00:21.849   [clj_http.core$request invoke core.clj 346]
00:00:21.849   [clj_http.core$request invokeStatic core.clj 347]
00:00:21.849   [clj_http.core$request invoke core.clj 346]
00:00:21.849   [clojure.lang.Var invoke Var.java 381]
00:00:21.849   [clj_http.client$wrap_request_timing$fn__12211 invoke client.clj 1030]
00:00:21.849   [clj_http.client$wrap_async_pooling$fn__12219 invoke client.clj 1063]
00:00:21.849   [clj_http.headers$wrap_header_map$fn__11229 invoke headers.clj 147]
00:00:21.849   [clj_http.client$wrap_query_params$fn__12109 invoke client.clj 790]
00:00:21.849   [clj_http.client$wrap_basic_auth$fn__12115 invoke client.clj 813]
00:00:21.849   [clj_http.client$wrap_oauth$fn__12120 invoke client.clj 830]
00:00:21.849   [clj_http.client$wrap_user_info$fn__12129 invoke client.clj 850]
00:00:21.849   [clj_http.client$wrap_url$fn__12193 invoke client.clj 982]
00:00:21.849   [clj_http.client$wrap_decompression$fn__11927 invoke client.clj 414]
00:00:21.849   [clj_http.client$wrap_input_coercion$fn__12033 invoke client.clj 610]
00:00:21.849   [clj_http.client$wrap_additional_header_parsing$fn__12058 invoke client.clj 665]
00:00:21.849   [clj_http.client$wrap_output_coercion$fn__12020 invoke client.clj 554]
00:00:21.849   [clj_http.client$wrap_exceptions$fn__11880 invoke client.clj 248]
00:00:21.849   [clj_http.client$wrap_accept$fn__12073 invoke client.clj 708]
00:00:21.849   [clj_http.client$wrap_accept_encoding$fn__12080 invoke client.clj 730]
00:00:21.849   [clj_http.client$wrap_content_type$fn__12067 invoke client.clj 691]
00:00:21.849   [clj_http.client$wrap_form_params$fn__12166 invoke client.clj 932]
00:00:21.849   [clj_http.client$wrap_nested_params$fn__12188 invoke client.clj 967]
00:00:21.849   [clj_http.client$wrap_method$fn__12134 invoke client.clj 866]
00:00:21.849   [clj_http.cookies$wrap_cookies$fn__10452 invoke cookies.clj 131]
00:00:21.849   [clj_http.links$wrap_links$fn__11497 invoke links.clj 63]
00:00:21.849   [clj_http.client$wrap_unknown_host$fn__12196 invoke client.clj 993]
00:00:21.849   [clj_http.client$request_STAR_ invokeStatic client.clj 1165]
00:00:21.849   [clj_http.client$request_STAR_ invoke client.clj 1158]
00:00:21.849   [clj_http.client$get invokeStatic client.clj 1171]
00:00:21.849   [clj_http.client$get doInvoke client.clj 1167]
00:00:21.849   [clojure.lang.RestFn invoke RestFn.java 423]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9891$ec2_meta__9900$fn__9903$fn__9904 invoke aws_ec2.clj 26]
00:00:21.849   [clojure.lang.AFn applyToHelper AFn.java 152]
00:00:21.849   [clojure.lang.AFn applyTo AFn.java 144]
00:00:21.849   [clojure.core$apply invokeStatic core.clj 657]
00:00:21.849   [clojure.core$apply invoke core.clj 652]
00:00:21.849   [robert.bruce$try_try_again$fn__13713 invoke bruce.clj 167]
00:00:21.849   [robert.bruce$retry$fn__13700 invoke bruce.clj 137]
00:00:21.849   [robert.bruce$retry invokeStatic bruce.clj 136]
00:00:21.849   [robert.bruce$retry invoke bruce.clj 127]
00:00:21.849   [robert.bruce$retry$fn__13702 invoke bruce.clj 156]
00:00:21.849   [clojure.core$trampoline invokeStatic core.clj 6231]
00:00:21.849   [clojure.core$trampoline invokeStatic core.clj 6220]
00:00:21.849   [clojure.core$trampoline doInvoke core.clj 6220]
00:00:21.849   [clojure.lang.RestFn invoke RestFn.java 439]
00:00:21.849   [robert.bruce$try_try_again invokeStatic bruce.clj 167]
00:00:21.849   [robert.bruce$try_try_again doInvoke bruce.clj 161]
00:00:21.849   [clojure.lang.RestFn invoke RestFn.java 423]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9891$ec2_meta__9900$fn__9903 invoke aws_ec2.clj 21]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9891$ec2_meta__9900 invoke aws_ec2.clj 17]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9891$ec2_meta__9900$fn__9901 invoke aws_ec2.clj 19]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9891$ec2_meta__9900 invoke aws_ec2.clj 17]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9929$this_host_QMARK___9934$fn__9935 invoke aws_ec2.clj 38]
00:00:21.849   [runbld.hosting.aws_ec2$fn__9929$this_host_QMARK___9934 invoke aws_ec2.clj 35]
00:00:21.849   [runbld.hosting.factory$fn__10160$make_hosting__10165$fn__10166 invoke factory.clj 18]
00:00:21.849   [runbld.hosting.factory$fn__10160$make_hosting__10165 invoke factory.clj 14]
00:00:21.849   [runbld.system$fn__10290$make_hosting__10295$fn__10296$iter__10297__10301$fn__10302$fn__10303 invoke system.clj 65]
00:00:21.849   [runbld.system$fn__10290$make_hosting__10295$fn__10296$iter__10297__10301$fn__10302 invoke system.clj 64]
00:00:21.849   [clojure.lang.LazySeq sval LazySeq.java 40]
00:00:21.849   [clojure.lang.LazySeq seq LazySeq.java 49]
00:00:21.849   [clojure.lang.RT seq RT.java 528]
00:00:21.849   [clojure.core$seq__5125 invokeStatic core.clj 137]
00:00:21.849   [clojure.core$apply invokeStatic core.clj 652]
00:00:21.849   [clojure.core$apply invoke core.clj 652]
00:00:21.849   [runbld.system$fn__10290$make_hosting__10295$fn__10296 invoke system.clj 64]
00:00:21.849   [runbld.system$fn__10290$make_hosting__10295 invoke system.clj 62]
00:00:21.849   [runbld.system$fn__10333$inspect_system__10338$fn__10339 invoke system.clj 79]
00:00:21.849   [runbld.system$fn__10333$inspect_system__10338 invoke system.clj 73]
00:00:21.849   [runbld.system$fn__10356$add_system_facts__10361$fn__10362 invoke system.clj 83]
00:00:21.849   [runbld.system$fn__10356$add_system_facts__10361 invoke system.clj 81]
00:00:21.849   [runbld.main$fn__10495$fn__10496 invoke main.clj 78]
00:00:21.849   [runbld.main$fn__10488$fn__10489 invoke main.clj 77]
00:00:21.849   [runbld.main$fn__10481$fn__10482 invoke main.clj 76]
00:00:21.849   [runbld.main$fn__10474$fn__10475 invoke main.clj 75]
00:00:21.849   [runbld.main$fn__10467$fn__10468 invoke main.clj 74]
00:00:21.849   [runbld.main$fn__10460$fn__10461 invoke main.clj 73]
00:00:21.849   [runbld.main$fn__10453$fn__10454 invoke main.clj 72]
00:00:21.849   [runbld.util.debug$with_debug_logging invokeStatic debug.clj 85]
00:00:21.849   [runbld.util.debug$with_debug_logging invoke debug.clj 80]
00:00:21.849   [runbld.main$fn__10447$fn__10448 invoke main.clj 71]
00:00:21.849   [runbld.main$fn__10440$fn__10441 invoke main.clj 70]
00:00:21.849   [runbld.main$_main invokeStatic main.clj 101]
00:00:21.849   [runbld.main$_main doInvoke main.clj 90]
00:00:21.849   [clojure.lang.RestFn applyTo RestFn.java 137]
00:00:21.849   [runbld.main main nil -1]]}
00:00:26.866 Build step 'Execute shell' marked build as failure
```