### PR TITLE
catch all throwables

### DIFF
--- a/src/clj/runbld/system.clj
+++ b/src/clj/runbld/system.clj
@@ -86,6 +86,7 @@
   (try-try-again
    {:sleep 5000
     :tries 5
+    :catch java.lang.Throwable
     :error-hook report-retry}
    #(let [facter (facter/make-facter)]
       (merge

--- a/test/runbld/system_test.clj
+++ b/test/runbld/system_test.clj
@@ -26,11 +26,11 @@
     (let [tries (atom 0)
           orig-retry system/report-retry]
       (with-redefs [facter/make-facter (fn []
-                                         (throw (Exception. "test failure")))
+                                         (assert nil "test failure"))
                     system/report-retry (fn [err]
                                           (swap! tries inc)
                                           (orig-retry err))]
-        (is (thrown-with-msg? Exception #"test failure"
+        (is (thrown-with-msg? AssertionError #"test failure"
                               (system/inspect-system ".")))
         (is (= 5 @tries)))))
   (testing "success after retries"


### PR DESCRIPTION
we shell out to run facter which has an assertion for an exit code of
0.  This AssertionError is not caught by default in try-try-again,
this fixes that.