### PR TITLE
Add a good hint to the repository type error message.

### DIFF
--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -33,7 +33,8 @@
       :else
       (let [msg (str source-dir ": unknown repository type "
                      "(only know about git and svn currently). "
-                     "Most common cause: run from the wrong directory.")
+                     "Most common cause: no clone exists in ${PWD} directory; "
+                     " ensure a clone is present and basedir is correct.")
             f (io/file source-dir)
             exists? (.exists f)]
         (debug/log msg

--- a/src/clj/runbld/vcs/middleware.clj
+++ b/src/clj/runbld/vcs/middleware.clj
@@ -32,7 +32,8 @@
 
       :else
       (let [msg (str source-dir ": unknown repository type "
-                     "(only know about git and svn currently)")
+                     "(only know about git and svn currently). "
+                     "Most common cause: run from the wrong directory.")
             f (io/file source-dir)
             exists? (.exists f)]
         (debug/log msg


### PR DESCRIPTION
This message typically comes from executing in the wrong directory,
so point any humans reading it toward that as the first thing to
check for.