### PR TITLE
Prefer user specified branches

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -48,16 +48,15 @@
         :hits :hits first :_source)))
 
 (defn query-for-build [keyword-mapping? job-name vcs-provider]
-  (let [clauses (if keyword-mapping?
-                  ;; pre-5.0 mapping for string fields
-                  [{:term {:build.job-name job-name}}
-                   {:term {:process.status "SUCCESS"}}
-                   {:term {:vcs.provider vcs-provider}}]
-                  ;; post-5.0 mapping for string fields, before the
-                  ;; mapping was updated in the code
-                  [{:term {:build.job-name.keyword job-name}}
-                   {:term {:process.status.keyword "SUCCESS"}}
-                   {:term {:vcs.provider.keyword vcs-provider}}])]
+  (let [clauses
+        [{:term {:build.job-name job-name}}
+         {:term {:process.status "SUCCESS"}}
+         {:bool {:minimum_should_match 1
+                 :should
+                 [{:term {:build.user-specified-branch false}}
+                  {:bool {:must_not
+                          {:exists
+                           {:field :build.user-specified-branch}}}}]}}]]
     {:body
      {:query
       {:bool

--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -175,7 +175,8 @@
    (s/optional-key :number)    s/Str
    (s/optional-key :executor)  s/Str
    (s/optional-key :node)      s/Str
-   (s/optional-key :last-success) LastGoodBuild})
+   (s/optional-key :last-success) LastGoodBuild
+   (s/optional-key :user-specified-branch) s/Bool})
 
 (def OptsWithSys
   (merge Opts
@@ -336,6 +337,7 @@
                :executor            m/keyword
                :node                m/keyword
                :metadata            m/multi-string
+               :user-specified-branch m/boolean
                :last-success
                {:properties
                 {:id                m/keyword

--- a/test/config/main.yml
+++ b/test/config/main.yml
@@ -18,3 +18,10 @@ email:
   template-txt: templates/email.mustache.txt
   template-html: templates/email.mustache.html
 
+profiles:
+  - '^elastic\+foo\+master\+user-specified$':
+      scm:
+        clone: true
+        url: "/tmp/git/user-intake"
+        branch: master
+        wipe-workspace: false

--- a/test/runbld/main_test.clj
+++ b/test/runbld/main_test.clj
@@ -747,7 +747,19 @@
                    (get-in res-2 [:store-result
                                   :build-doc
                                   :vcs
-                                  :commit-id]))))))
+                                  :commit-id])))))
+        ;; user specified commits should not affect the
+        ;; last-good-commit
+        (is (= lgc
+               (get-in (build/last-good-build
+                        job-name
+                        opts-1
+                        (runbld.vcs.middleware/make-repo
+                         {:process {:cwd source-dir}
+                          :build {:org "elastic"
+                                  :project "foo"
+                                  :branch "master"}}))
+                       [:vcs :commit-id]))))
       (finally
         (io/rmdir-r dest-dir)
         (io/rmdir-r source-dir)))))

--- a/test/runbld/main_test.clj
+++ b/test/runbld/main_test.clj
@@ -687,3 +687,67 @@
       (finally
         (io/rmdir-r periodic-dir)
         (io/rmdir-r intake-dir)))))
+
+(s/deftest user-specified-commit
+  ;; This tests that branch_specifier is honored.  we basically need a
+  ;; repo with several commits where lgc is some commit A and
+  ;; branch_specifier points to commit B
+  (let [script (if (opts/windows?) "test/success.bat" "test/success.bash")
+        job-name "elastic+foo+master+user-specified"
+        source-dir "/tmp/runbld/user-source"
+        dest-dir "/tmp/runbld/user-dest"]
+    ;; because we need to use the scm feature we need the repo to be
+    ;; somewhere on disk at a known location, therefore we should make
+    ;; sure to clean up before trying anything
+    (if (.exists (jio/file dest-dir))
+      (io/rmdir-r dest-dir))
+    (if (.exists (jio/file source-dir))
+      (io/rmdir-r source-dir))
+    (try
+      ;; create the dummy repo in source-dir and clone it to dest-dir
+      (git/init-test-clone dest-dir source-dir)
+      (let [first-commit (:commit-id (git/head-commit source-dir))
+            [opts-1 res-1]
+            (run ["-c" "test/config/main.yml"
+                  "-j" job-name
+                  "-d" dest-dir
+                  script])
+            ;; at this point we should have a l-g-c at the first
+            ;; commit, so we will add a second commit that the
+            ;; user can specify with branch_specifier
+            lgc (get-in (build/last-good-build
+                         job-name
+                         opts-1
+                         (runbld.vcs.middleware/make-repo
+                          {:process {:cwd source-dir}
+                           :build {:org "elastic"
+                                   :project "foo"
+                                   :branch "master"}}))
+                        [:vcs :commit-id])
+            _ (git/add-test-commit source-dir)
+            second-commit (:commit-id (git/head-commit source-dir))
+            ;; we will also add a third commit to ensure we aren't
+            ;; accidentally getting the head commit later
+            _ (git/add-test-commit source-dir)
+            third-commit (:commit-id (git/head-commit source-dir))]
+        (is (= 0 (:exit-code res-1)))
+        (is (= lgc first-commit))
+        ;; specify the second commit in the "environment" and run the
+        ;; script again, specifying that we want the l-g-c
+        (with-redefs [environ/env {:dev "true"
+                                   :branch-specifier second-commit}]
+          (let [[opts-2 res-2]
+                (run ["-c" "test/config/main.yml"
+                      "-j" job-name
+                      "-d" dest-dir
+                      "--last-good-commit" job-name
+                      script])]
+            (is (= 0 (:exit-code res-2)))
+            (is (= second-commit
+                   (get-in res-2 [:store-result
+                                  :build-doc
+                                  :vcs
+                                  :commit-id]))))))
+      (finally
+        (io/rmdir-r dest-dir)
+        (io/rmdir-r source-dir)))))

--- a/test/runbld/scm_test.clj
+++ b/test/runbld/scm_test.clj
@@ -11,36 +11,36 @@
 
 (deftest branch-selection
   (testing "Branch selection chooses the right option."
-    (is (= {:branch "1.6" :commit nil}
+    (is (= {:branch "1.6" :commit nil :user-specified-branch false}
            (test-choose-branch nil "1.6" "3.2"))
         "env is nil, should be ignored")
-    (is (= {:branch "1.6" :commit nil}
+    (is (= {:branch "1.6" :commit nil :user-specified-branch false}
            (test-choose-branch "" "1.6" "3.2"))
         "env is '', should be ignored")
-    (is (= {:branch "1.6" :commit nil}
+    (is (= {:branch "1.6" :commit nil :user-specified-branch false}
            (test-choose-branch "refs/heads/3.2" "1.6" "3.2"))
         "env and build are the 'same', should choose scm")
-    (is (= {:branch "6.4" :commit nil}
+    (is (= {:branch "6.4" :commit nil :user-specified-branch true}
            (test-choose-branch "6.4" "1.6" "3.2"))
         "env and build are different, should choose env"))
   (testing "Branch selection can handle commits."
-    (is (= {:commit "026aac0" :branch "1.6"}
+    (is (= {:commit "026aac0" :branch "1.6" :user-specified-branch true}
            (test-choose-branch "026aac0" "1.6" "3.2"))
         "Commits are supported")
-    (is (= {:commit "026aac0" :branch "3.2"}
+    (is (= {:commit "026aac0" :branch "3.2" :user-specified-branch false}
            (test-choose-branch nil "026aac0" "3.2"))
         "Commits are supported, even when not in the env")
-    (is (= {:commit "abc1234" :branch "3.2"}
+    (is (= {:commit "abc1234" :branch "3.2" :user-specified-branch true}
            (test-choose-branch "abc1234" "026aac0" "3.2"))
         "The first of multiple commits will be chosen.")
     ;; I don't know what would lead to this, but if its commits all
     ;; the way down, choose the first and assume we're working with
     ;; master
-    (is (= {:commit "abc1234" :branch "master"}
+    (is (= {:commit "abc1234" :branch "master" :user-specified-branch true}
            (test-choose-branch "abc1234" "026aac0" "def5678"))
         "Use master if no branches are found")
     (testing "A commit is ignored if it's preceded by a branch"
-      (is (= {:branch "6.4" :commit nil}
+      (is (= {:branch "6.4" :commit nil :user-specified-branch true}
              (test-choose-branch "6.4" "026aac0" "3.2")))
-      (is (= {:branch "1.6" :commit nil}
+      (is (= {:branch "1.6" :commit nil :user-specified-branch false}
              (test-choose-branch nil "1.6" "026aac0"))))))


### PR DESCRIPTION
When the branch is specified in the environment (generally when a user sets the `branch_specifier` parameter in jenkins) it will be ignored when `--last-good-commit` is also specified.  This PR reverses that and will prefer the environment over the last-good-commit.

Additionally, it will index that the user overrode the commit and filter such builds from future last-good-commits.  I don't believe that manually running a job with an arbitrary commit should affect the normal operation of the last-good-commit.