### PR TITLE
Deepen a shallow clone before checking out the last-good-commit

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -87,6 +87,15 @@
     (or (build false)
         (build true))))
 
+(defn checkout-last-good-commit
+  "Checks out the commit id found in the last good build.  Will deepen
+  a shallow clone to include that commit, if necessary."
+  [vcs-repo {{:keys [commit-id commit-time]} :vcs :as build}]
+  (if (runbld.vcs/is-shallow? vcs-repo)
+    (runbld.vcs/fetch-latest vcs-repo :shallow-since commit-time)
+    (runbld.vcs/fetch-latest vcs-repo))
+  (runbld.vcs/check-out vcs-repo commit-id))
+
 (defn maybe-find-last-good-build-and-checkout
   "Usually this should find /something/.
 
@@ -94,8 +103,7 @@
 
     * Fresh install
     * New --last-good-commit job name
-    * Bogus --last-good-commit job name
-  "
+    * Bogus --last-good-commit job name"
   [opts]
   (let [check-out? (boolean (:last-good-commit opts))
         job-name (if check-out?
@@ -107,8 +115,7 @@
        ;; only actually check out as working copy if the command line
        ;; opt has been supplied
        (when check-out?
-         (runbld.vcs/fetch-latest vcs-repo)
-         (runbld.vcs/check-out vcs-repo (-> build :vcs :commit-id)))
+         (checkout-last-good-commit vcs-repo build))
        build)
      check-out?]))
 

--- a/src/clj/runbld/vcs.clj
+++ b/src/clj/runbld/vcs.clj
@@ -3,5 +3,7 @@
 (defprotocol VcsRepo
   (log-latest [_] "Log map for latest commit")
   (check-out [_ commit] "Set working copy to version at commit")
-  (fetch-latest [_] "Updates local checkout to latest version")
+  (fetch-latest [_] [_ & {:as opts-map}]
+    "Updates local checkout to latest version")
+  (is-shallow? [_])
   (provider [_] "What kind of VCS?"))

--- a/test/runbld/build_test.clj
+++ b/test/runbld/build_test.clj
@@ -1,7 +1,10 @@
 (ns runbld.build-test
   (:require
+   [clj-git.core :as git]
    [clojure.test :refer :all]
    [runbld.build :as build]
+   [runbld.io :as io]
+   [runbld.vcs.git :as vcs-git]
    [schema.test :as s]))
 
 (use-fixtures :once schema.test/validate-schemas)
@@ -28,3 +31,36 @@
          :org-project-branch "elastic/apm-agent-nodejs#master"
          :project "apm-agent-nodejs"}
         (build/split-job-name s)))))
+
+(deftest test-checkout
+  (let [clone-dir "tmp/git/test-checkout"
+        commit-time "2017-05-05T20:11:58Z"
+        commit-id "9261b6332464bce8e63f6e42a61adb59062a56cc"
+        commit-to-fetch {:vcs
+                         {:commit-id commit-id
+                          :commit-time "2017-05-05T20:11:58Z"}}
+        vcs-repo (vcs-git/make-repo clone-dir "elastic" "runbld" "master")]
+    (try
+      (when (.exists (clojure.java.io/file clone-dir))
+        (io/rmdir-r clone-dir))
+      (git/git-clone clone-dir
+                     "git@github.com:elastic/runbld.git"
+                     ["--depth" "1"])
+      (is (vcs-git/is-shallow? vcs-repo)
+          "We should have a shallow repo.")
+      (is (not (= commit-id (:commit-id (vcs-git/log-latest vcs-repo))))
+          "The head commit should be different than some old commit.")
+      (build/checkout-last-good-commit vcs-repo commit-to-fetch)
+      (is (vcs-git/is-shallow? vcs-repo)
+          "It's still shallow, just less so than before")
+      (let [commit (vcs-git/log-latest vcs-repo)]
+        (is (= (:commit-time commit) commit-time)
+            "The commit time should be the one we specified")
+        (is (= (:commit-id commit) commit-id)
+            "The commit id should be the one we specified")
+        (is (re-find #"Use a real template for text/plain content"
+                     (:log-pretty commit))
+            "The log should be what we expect, too."))
+      (finally
+        (when (.exists (clojure.java.io/file clone-dir))
+          (io/rmdir-r clone-dir))))))


### PR DESCRIPTION
In the case of a shallow clone we will not have the l-g-c in the local
checkout (unless it is also HEAD) so we need to fetch it.  Using
'shallow-since' with the lgc commit-time should be more deterministic
than using 'depth' or 'shallow-since' with an arbitrary time frame.