### PR TITLE
add ability to disable gathering/injecting metadata

### DIFF
--- a/src/clj/runbld/build.clj
+++ b/src/clj/runbld/build.clj
@@ -225,8 +225,10 @@
   opts)
 
 (defn add-build-meta
-  [proc opts]
-  (-> opts
-      set-build-meta-environment
-      proc
-      record-build-meta))
+  [proc {{:keys [disable]} :build-metadata :keys [logger] :as opts}]
+  (when disable
+    (logger "Storing/retrieving build metadata is disabled."))
+  (cond-> opts
+    (not disable) set-build-meta-environment
+    true          proc
+    (not disable) record-build-meta))

--- a/src/clj/runbld/opts.clj
+++ b/src/clj/runbld/opts.clj
@@ -64,7 +64,10 @@
     :success true
     :failure true
     :template "templates/slack.mustache.json"
-    :disable false}})
+    :disable false}
+
+   :build-metadata
+   {:disable false}})
 
 (s/defn merge-profiles :- java.util.Map
   [job-name :- s/Str

--- a/test/config/main.yml
+++ b/test/config/main.yml
@@ -25,3 +25,6 @@ profiles:
         url: "/tmp/git/user-intake"
         branch: master
         wipe-workspace: false
+  - "disabled-metadata":
+      build-metadata:
+        disable: true


### PR DESCRIPTION
Metadata, in this context, refers to functionality in runbld where the wrapped script can output files with the name "build_metadata" and after the script is done running runbld will find those files and index their contents in ES.  In the future, when `--last-good-commit` is used, runbld will take the stored metadata and inject it into the environment for the wrapped script to use.

In some projects with many files this process can take awhile and if there is no plan to use the functionality, it might as well be disabled.  This PR offers that capability.  The metadata feature remains enabled by default.