### PR TITLE
Dont explode on gce

### DIFF
--- a/src/clj/runbld/hosting/aws_ec2.clj
+++ b/src/clj/runbld/hosting/aws_ec2.clj
@@ -3,6 +3,7 @@
    [clj-http.client :as http]
    [robert.bruce :refer [try-try-again]]
    [runbld.hosting :refer [HostingProvider] :as hosting]
+   [runbld.io :as rio]
    [runbld.schema :refer :all]
    [schema.core :as s]
    [slingshot.slingshot :refer [try+ throw+]]))
@@ -18,20 +19,23 @@
   ([]
    (ec2-meta "/"))
   ([postfix]
-   (try-try-again
-    {:sleep 500
-     :tries 20}
-    #(try+
-      (:body
-       (http/get (str "http://169.254.169.254/latest/meta-data" postfix)
-                 {:socket-timeout 500 :conn-timeout 500}))
-      (catch java.net.SocketTimeoutException _)
-      (catch org.apache.http.conn.ConnectTimeoutException _)
-      (catch org.apache.http.NoHttpResponseException _)
-      (catch java.net.ConnectException _)
-      ;; Non-AWS Windows
-      (catch java.net.SocketException _)
-      (catch java.net.UnknownHostException _)))))
+   (try
+     (try-try-again
+      {:sleep 500
+       :tries 20}
+      #(try+
+        (:body
+         (http/get (str "http://169.254.169.254/latest/meta-data" postfix)
+                   {:socket-timeout 500 :conn-timeout 500}))
+        (catch java.net.SocketTimeoutException _)
+        (catch org.apache.http.conn.ConnectTimeoutException _)
+        (catch org.apache.http.NoHttpResponseException _)
+        (catch java.net.ConnectException _)
+        ;; Non-AWS Windows
+        (catch java.net.SocketException _)
+        (catch java.net.UnknownHostException _)))
+     (catch Exception e
+       (rio/log "Warning: Got exception during ec2-meta." (.getMessage e))))))
 
 (s/defn this-host? :- s/Bool
   "Is this host in AWS EC2?"

--- a/src/clj/runbld/hosting/aws_ec2.clj
+++ b/src/clj/runbld/hosting/aws_ec2.clj
@@ -39,8 +39,8 @@
 
 (s/defn this-host? :- s/Bool
   "Is this host in AWS EC2?"
-  ([]
-   (boolean (ec2-meta))))
+  []
+  (boolean (ec2-meta "/ami-id")))
 
 (defrecord AwsEc2Hosting [facts]
   HostingProvider


### PR DESCRIPTION
On GCE (or any other cloud, I'd imagine) the ec2-meta call would eventually fail out of all retries because the particular url it's trying to hit doesn't exist.  The exception would then bubble out and kill the build.

Commit e0c591c prevents the bubbling by assuming all non-200 errors.  This not only prevents `this-host?` from killing runbld, but will prevent any other blips from doing so.

Commit 93fa632 changes the `this-host?` to look up a specific address in the hopes that it prevents a future almost-ec2 cloud from causing false matches.