### PR TITLE
Parse the smtp port if it is a string

### DIFF
--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -164,11 +164,7 @@
                   [:email :port]
                   #(if (string? %)
                      (try
-                       (Integer/parseInt %)
-                       (catch NumberFormatException _
-                         (logger "Failed to parse smtp port" %
-                                 "trying default port 587 instead.")
-                         587))
+                       (Integer/parseInt %))
                      %))
        (make-context opts build-doc failure-docs))
       (logger "NO MAIL GENERATED"))))

--- a/test/config/main.yml
+++ b/test/config/main.yml
@@ -28,3 +28,12 @@ profiles:
   - "disabled-metadata":
       build-metadata:
         disable: true
+  - "int-email-port":
+      email:
+        port: 1234
+  - "string-email-port":
+      email:
+        port: "2525"
+  - "bad-string-email-port":
+      email:
+        port: "ohnoes"

--- a/test/config/main.yml
+++ b/test/config/main.yml
@@ -28,12 +28,12 @@ profiles:
   - "disabled-metadata":
       build-metadata:
         disable: true
-  - "int-email-port":
+  - "^int-email-port":
       email:
         port: 1234
-  - "string-email-port":
+  - "^string-email-port":
       email:
         port: "2525"
-  - "bad-string-email-port":
+  - "^bad-string-email-port":
       email:
         port: "ohnoes"

--- a/test/runbld/email_test.clj
+++ b/test/runbld/email_test.clj
@@ -172,3 +172,39 @@
                        "test/fail.bat"
                        "test/fail.bash"))))
         (is (= (:reply-to @email) "replyto@example.com"))))))
+
+(deftest string-port
+  (let [conn-atom (atom [])
+        out (java.io.StringWriter.)]
+    (with-redefs [mail/send-message (fn [conn msg]
+                                      (reset! conn-atom conn))]
+      (git/with-tmp-repo [d "tmp/git/int-email-port"]
+        (binding [*out* out
+                  *err* out]
+          (run (conj ["-c" "test/config/main.yml"
+                      "-j" "int-email-port"
+                      "-d" d]
+                     (if (opts/windows?)
+                       "test/fail.bat"
+                       "test/fail.bash"))))
+        (is (= 1234 (:port @conn-atom))))
+      (git/with-tmp-repo [d "tmp/git/string-email-port"]
+        (binding [*out* out
+                  *err* out]
+          (run (conj ["-c" "test/config/main.yml"
+                      "-j" "string-email-port"
+                      "-d" d]
+                     (if (opts/windows?)
+                       "test/fail.bat"
+                       "test/fail.bash"))))
+        (is (= 2525 (:port @conn-atom))))
+      (git/with-tmp-repo [d "tmp/git/bad-string-email-port"]
+        (binding [*out* out
+                  *err* out]
+          (run (conj ["-c" "test/config/main.yml"
+                      "-j" "bad-string-email-port"
+                      "-d" d]
+                     (if (opts/windows?)
+                       "test/fail.bat"
+                       "test/fail.bash"))))
+        (is (= 587 (:port @conn-atom)))))))

--- a/test/runbld/email_test.clj
+++ b/test/runbld/email_test.clj
@@ -14,7 +14,9 @@
    [schema.test]
    [stencil.core :as mustache]))
 
-(use-fixtures :each (ts/redirect-logging-fixture))
+(def log-atom (atom []))
+
+(use-fixtures :each (ts/redirect-logging-fixture log-atom))
 (use-fixtures :once
   schema.test/validate-schemas
   ts/dont-die-fixture)
@@ -174,7 +176,7 @@
         (is (= (:reply-to @email) "replyto@example.com"))))))
 
 (deftest string-port
-  (let [conn-atom (atom [])
+  (let [conn-atom (atom nil)
         out (java.io.StringWriter.)]
     (with-redefs [mail/send-message (fn [conn msg]
                                       (reset! conn-atom conn))]
@@ -188,6 +190,7 @@
                        "test/fail.bat"
                        "test/fail.bash"))))
         (is (= 1234 (:port @conn-atom))))
+      (reset! conn-atom nil)
       (git/with-tmp-repo [d "tmp/git/string-email-port"]
         (binding [*out* out
                   *err* out]
@@ -198,6 +201,8 @@
                        "test/fail.bat"
                        "test/fail.bash"))))
         (is (= 2525 (:port @conn-atom))))
+      (reset! conn-atom nil)
+      (reset! log-atom [])
       (git/with-tmp-repo [d "tmp/git/bad-string-email-port"]
         (binding [*out* out
                   *err* out]
@@ -207,4 +212,7 @@
                      (if (opts/windows?)
                        "test/fail.bat"
                        "test/fail.bash"))))
-        (is (= 587 (:port @conn-atom)))))))
+        (is (nil? @conn-atom)
+            "conn-atom shouldn't be set because of an exception")
+        (is (re-find #"NumberFormatException" (str @log-atom)))
+        (is (re-find #"For input string:.*ohnoes" (str @log-atom)))))))


### PR DESCRIPTION
Sometimes the port might be specified as a string in the config.  The schema defines that to be okay, but it actually breaks email sending.  This PR will attempt to parse the port at the time of sending.