### PR TITLE
Fail fast for non-AWS hosts using the same metadata server

### DIFF
--- a/src/clj/runbld/hosting/aws_ec2.clj
+++ b/src/clj/runbld/hosting/aws_ec2.clj
@@ -27,6 +27,9 @@
         (:body
          (http/get (str "http://169.254.169.254/latest/meta-data" postfix)
                    {:socket-timeout 500 :conn-timeout 500}))
+        ;; If we get a 404 then this is another cloud provider which uses the same
+        ;; metadata server IP as AWS but is not AWS
+        (catch [:status 404] _)
         (catch java.net.SocketTimeoutException _)
         (catch org.apache.http.conn.ConnectTimeoutException _)
         (catch org.apache.http.NoHttpResponseException _)


### PR DESCRIPTION
The current handling for non-AWS hosts is that it would keep on trying to connect to the metadata URL for 1 minute before giving up. Now it will fail fast as soon as the first 404 is returned. 

Before:
```
06:28:16 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
06:28:25 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
06:28:35 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
06:28:44 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
06:28:54 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
06:29:04 runbld>>> Warning: Got exception during ec2-meta. clj-http: status 404
```

I built and tested this on a GCP host and an AWS host and saw that AWS is still getting the expected metadata. 