### PR TITLE
More debug logging

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,6 @@
 * runbld changes
+** 1.5.17
+   - added more debug logging
 ** 1.5.16
    - prevent errors from =runbld.hosting.aws-ec2/ec2-meta= from
      killing the build

--- a/project.clj
+++ b/project.clj
@@ -8,7 +8,6 @@
   :url "https://github.com/elastic/runbld"
   :license {:name "Apache License, Version 2.0"
             :url "https://www.apache.org/licenses/LICENSE-2.0"}
-  :repositories {"jenkins" "http://repo.jenkins-ci.org/releases"}
   :global-vars {*warn-on-reflection* false}
   :min-lein-version "2.0.0"
   :exclusions [org.clojure/clojure

--- a/src/clj/runbld/notifications/email.clj
+++ b/src/clj/runbld/notifications/email.clj
@@ -7,6 +7,7 @@
    [runbld.notifications :as n]
    [runbld.schema :refer :all]
    [runbld.store :as store]
+   [runbld.util.debug :as debug]
    [runbld.util.email :as email]
    [runbld.vcs :as vcs]
    [schema.core :as s]
@@ -176,5 +177,6 @@
                            :build-doc {s/Keyword s/Any}}
             :email OptsEmail
             s/Keyword s/Any}]
+  (debug/log "Send email stage")
   (assoc opts :email-result
          (io/try-log (maybe-send! opts (-> opts :store-result :addr)))))

--- a/src/clj/runbld/notifications/slack.clj
+++ b/src/clj/runbld/notifications/slack.clj
@@ -9,6 +9,7 @@
    [runbld.notifications :as n]
    [runbld.schema :refer :all]
    [runbld.store :as store]
+   [runbld.util.debug :as debug]
    [runbld.util.http :refer [wrap-retries]]
    [schema.core :as s]
    [stencil.core :as mustache]))
@@ -97,5 +98,6 @@
                            :build-doc {s/Keyword s/Any}}
             :slack OptsSlack
             s/Keyword s/Any}]
+  (debug/log "Send slack stage")
   (assoc opts :slack-result
          (io/try-log (maybe-send! opts (-> opts :store-result :addr)))))

--- a/src/clj/runbld/store.clj
+++ b/src/clj/runbld/store.clj
@@ -301,6 +301,7 @@
   [opts :- {(s/optional-key :test-report) TestReport
             (s/optional-key :process-result) (s/maybe EitherProcessResult)
             s/Keyword s/Any}]
+  (debug/log "Storing result")
   (let [{:keys [test-report process-result]} opts]
     (assoc opts :store-result
            (save! opts process-result test-report))))

--- a/src/clj/runbld/tests.clj
+++ b/src/clj/runbld/tests.clj
@@ -2,9 +2,11 @@
   (:require
    [runbld.schema :refer :all]
    [runbld.tests.junit]
+   [runbld.util.debug :as debug]
    [schema.core :as s]))
 
 (defn capture-failures [workspace]
+  (debug/log "finding failures")
   (runbld.tests.junit/find-failures workspace))
 
 (defn anything-to-report? [summary]
@@ -24,4 +26,5 @@
                             s/Keyword s/Any}
   [opts :- {:process OptsProcess
             s/Keyword s/Any}]
+  (debug/log "Add Test Report")
   (assoc opts :test-report (report (-> opts :process :cwd))))

--- a/test/runbld/process_test.clj
+++ b/test/runbld/process_test.clj
@@ -113,7 +113,7 @@
             env (proc/update-path {path-key path
                                    :JAVA_HOME "javahome"})
             expected (if (io/windows?) :Path :PATH)]
-        (is (= (get env path-key) )))))
+        (is (= (get env path-key) (str "javahome/bin:" path))))))
   (testing "Updating the path works when there is no path in the env"
     (let [env (proc/update-path {:JAVA_HOME "javahome"})]
       (is (re-find #"^javahome/bin:" (:PATH env))

--- a/test/runbld/tests_test.clj
+++ b/test/runbld/tests_test.clj
@@ -80,8 +80,8 @@
     (let [out (with-out-str (tests/capture-failures "test/xmls"))
           log (debug/get-log)]
       (is (re-find #"Failed to parse" out))
-      (is (re-find #"(?m)ErrorHandlerWrapper.createSAXParseException"
-                   (second log))))
+      (is (some #(re-find #"(?m)ErrorHandlerWrapper.createSAXParseException" %)
+                log)))
     (catch Exception e
       (is false "There shouldn't have been any exceptions")
       (stacktrace/print-cause-trace e))))


### PR DESCRIPTION
Ran into an odd case where some Windows builds were producing a StackOverflowException.  The stacktrace is pretty useless as the stack explosion is all happening inside clojure functions.  I cannot trace it back to an exact line in runbld and while I can narrow it down based on existing logging, I wanted more to be sure.