### PR TITLE
Add junit output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-target/
+/target/
 /classes
 /checkouts
 /pom.xml
@@ -15,7 +15,8 @@ target/
 .stdout.log
 /envg*
 *.pyc
-TEST-*
 /test.log
 /.cider-history
 /test/elasticsearch-src
+maven-status/
+com.example.AppTest.txt

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,11 @@ endif
 	rm -rf tmp/git
 	lein do clean, test
 
+package: test
+	./check.sh
+	git rev-parse HEAD >resources/build.txt
+	LEIN_SNAPSHOTS_IN_RELEASE=whynot lein package
+
 junit:
 ifndef GOLANG
 	$(error "golang not installed")
@@ -32,8 +37,3 @@ endif
 	go test -v | go-junit-report > TEST-no-errors.xml
 	-cd test/repo/go/some-errors && \
 	go test -v | go-junit-report > TEST-some-errors.xml
-
-package: test
-	./check.sh
-	git rev-parse HEAD >resources/build.txt
-	LEIN_SNAPSHOTS_IN_RELEASE=whynot lein package

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: package test
+.PHONY: junit package test
 
 FACTER := $(shell command -v facter 2>/dev/null)
 GOLANG := $(shell command -v go 2>/dev/null)
@@ -9,6 +9,10 @@ test:
 ifndef FACTER
 	$(error "facter not installed")
 endif
+	rm -rf tmp/git
+	lein do clean, test
+
+junit:
 ifndef GOLANG
 	$(error "golang not installed")
 endif
@@ -28,8 +32,6 @@ endif
 	go test -v | go-junit-report > TEST-no-errors.xml
 	-cd test/repo/go/some-errors && \
 	go test -v | go-junit-report > TEST-some-errors.xml
-	rm -rf tmp/git
-	lein do clean, test
 
 package: test
 	./check.sh

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ runbld /path/to/script.bash
 ## Install
 
 ```
-% lein package
+% make package
 ```
 
 Creates a Java binary in `target/` that you can run on OS X, Linux,
@@ -54,38 +54,16 @@ WRAPPER: FAILURE (1)
 %
 ```
 
+
 ## Development
 
 To see all of the tests passing there are several dependencies that
 need to be installed.
 
-### Java
-
-#### Maven
-
-Install via `apt-get`, `brew`, or whatever package manager your
-system uses.  You can also install [manually](https://maven.apache.org/install.html).
-
-#### Elasticsearch
+### Elasticsearch
 
 Download the latest Elasticsearch from [here](https://www.elastic.co/downloads/elasticsearch) and start it via
 `bin/elasticsearch`.
-
-### Python
-
-#### nose
-
-<http://nose.readthedocs.io/en/latest/>
-
-### go
-
-[Install Go](https://golang.org/doc/install)
-
-#### go-junit-report
-
-<https://github.com/jstemmer/go-junit-report>
-
-(Don't forget to add `$GOPATH/bin` to your path.)
 
 ### facter
 
@@ -98,6 +76,9 @@ one.
 It is packaged with the puppet agent and Puppet supplies
 installers and instructions for various operating systems are at
 <https://docs.puppet.com/puppet/latest/>
+
+The direct link for Mac is (as of this writing):
+https://downloads.puppetlabs.com/mac/10.13/PC1/x86_64/puppet-agent-latest.dmg
 
 It appears that the `facter` executable will end up in
 `/opt/puppetlabs/puppet/bin` or someplace similar.
@@ -120,17 +101,43 @@ with copying a ruby file to Mac OS X's default Ruby location.  I
 failed to figure out why and eventually worked around it by
 removing the Ruby deploy directives from the cmake files.
 
+
 ## Running tests
 
-Once all of the dependencies are installed go to the `runbld`
-directory and run `make`.  This will run a few sample projects and
-produce various Maven formatted XML test output files (some of
-which will look like failures, but don't panic). It finishes by
-running the Clojure tests, which should print a bunch of output
-but ultimately pass.
+`lein test` to run the tests and `lein tests!` to clean and test.
 
-Future test runs can skip the `make` step and run `lein test`
-directly.
+
+## Building the Junit test output
+
+The files are checked in, but if there is ever a need to rebuild them,
+some extra dependencies are necessary.  After they are installed go to
+the `runbld` directory and run `make junit`.  This will run a few
+sample projects and produce various Maven formatted XML test output
+files (some of which will look like failures, but don't panic).
+
+### Java
+
+#### Maven
+
+Install via `apt-get`, `brew`, or whatever package manager your
+system uses.  You can also install [manually](https://maven.apache.org/install.html).
+
+### Python
+
+#### nose
+
+<http://nose.readthedocs.io/en/latest/>
+
+### go
+
+[Install Go](https://golang.org/doc/install)
+
+#### go-junit-report
+
+<https://github.com/jstemmer/go-junit-report>
+
+(Don't forget to add `$GOPATH/bin` to your path.)
+
 
 # License
 

--- a/test/repo/go/no-errors/TEST-no-errors.xml
+++ b/test/repo/go/no-errors/TEST-no-errors.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="0" time="0.006" name="_/Users/runbld/elastic/src/runbld/test/repo/go/no-errors">
+		<properties>
+			<property name="go.version" value="go1.8.1"></property>
+		</properties>
+		<testcase classname="no-errors" name="TestHell" time="0.000"></testcase>
+	</testsuite>
+</testsuites>

--- a/test/repo/go/some-errors/TEST-some-errors.xml
+++ b/test/repo/go/some-errors/TEST-some-errors.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+	<testsuite tests="1" failures="1" time="0.007" name="_/Users/runbld/elastic/src/runbld/test/repo/go/some-errors">
+		<properties>
+			<property name="go.version" value="go1.8.1"></property>
+		</properties>
+		<testcase classname="some-errors" name="TestHello" time="0.000">
+			<failure message="Failed" type="">hello_test.go:6: Test failed!</failure>
+		</testcase>
+	</testsuite>
+</testsuites>

--- a/test/repo/java/no-errors/target/surefire-reports/TEST-com.example.AppTest.xml
+++ b/test/repo/java/no-errors/target/surefire-reports/TEST-com.example.AppTest.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite tests="1" failures="0" name="com.example.AppTest" time="0.002" errors="0" skipped="0">
+  <properties>
+    <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+    <property name="sun.boot.library.path" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib"/>
+    <property name="java.vm.version" value="25.131-b11"/>
+    <property name="gopherProxySet" value="false"/>
+    <property name="java.vm.vendor" value="Oracle Corporation"/>
+    <property name="maven.multiModuleProjectDirectory" value="/Users/runbld/elastic/src/runbld/test/repo/java/no-errors"/>
+    <property name="java.vendor.url" value="http://java.oracle.com/"/>
+    <property name="path.separator" value=":"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="java.vm.name" value="Java HotSpot(TM) 64-Bit Server VM"/>
+    <property name="file.encoding.pkg" value="sun.io"/>
+    <property name="user.country" value="US"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="sun.os.patch.level" value="unknown"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="user.dir" value="/Users/runbld/elastic/src/runbld/test/repo/java/no-errors"/>
+    <property name="java.runtime.version" value="1.8.0_131-b11"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment"/>
+    <property name="java.endorsed.dirs" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/endorsed"/>
+    <property name="os.arch" value="x86_64"/>
+    <property name="java.io.tmpdir" value="/var/folders/02/y03mldq14rq7kt1nfqm73c140000gn/T/"/>
+    <property name="line.separator" value="
+"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="os.name" value="Mac OS X"/>
+    <property name="classworlds.conf" value="/usr/local/Cellar/maven/3.5.0/libexec/bin/m2.conf"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.library.path" value="/Users/runbld/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."/>
+    <property name="maven.conf" value="/usr/local/Cellar/maven/3.5.0/libexec/conf"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.class.version" value="52.0"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="10.13.6"/>
+    <property name="library.jansi.path" value="/usr/local/Cellar/maven/3.5.0/libexec/lib/jansi-native/osx64"/>
+    <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="user.home" value="/Users/runbld"/>
+    <property name="user.timezone" value="America/New_York"/>
+    <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob"/>
+    <property name="java.specification.version" value="1.8"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="user.name" value="runbld"/>
+    <property name="java.class.path" value="/usr/local/Cellar/maven/3.5.0/libexec/boot/plexus-classworlds-2.5.2.jar"/>
+    <property name="java.vm.specification.version" value="1.8"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="java.home" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher test"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.language" value="en"/>
+    <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="1.8.0_131"/>
+    <property name="java.ext.dirs" value="/Users/runbld/Library/Java/Extensions:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java"/>
+    <property name="sun.boot.class.path" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/sunrsasign.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/classes"/>
+    <property name="java.vendor" value="Oracle Corporation"/>
+    <property name="maven.home" value="/usr/local/Cellar/maven/3.5.0/libexec"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="sun.cpu.isalist" value=""/>
+  </properties>
+  <testcase classname="com.example.AppTest" name="testGood" time="0.002"/>
+</testsuite>

--- a/test/repo/java/some-errors/target/surefire-reports/TEST-com.example.AppTest.xml
+++ b/test/repo/java/some-errors/target/surefire-reports/TEST-com.example.AppTest.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<testsuite tests="3" failures="1" name="com.example.AppTest" time="0.015" errors="1" skipped="0">
+  <properties>
+    <property name="java.runtime.name" value="Java(TM) SE Runtime Environment"/>
+    <property name="sun.boot.library.path" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib"/>
+    <property name="java.vm.version" value="25.131-b11"/>
+    <property name="gopherProxySet" value="false"/>
+    <property name="java.vm.vendor" value="Oracle Corporation"/>
+    <property name="maven.multiModuleProjectDirectory" value="/Users/runbld/elastic/src/runbld/test/repo/java/some-errors"/>
+    <property name="java.vendor.url" value="http://java.oracle.com/"/>
+    <property name="path.separator" value=":"/>
+    <property name="guice.disable.misplaced.annotation.check" value="true"/>
+    <property name="java.vm.name" value="Java HotSpot(TM) 64-Bit Server VM"/>
+    <property name="file.encoding.pkg" value="sun.io"/>
+    <property name="user.country" value="US"/>
+    <property name="sun.java.launcher" value="SUN_STANDARD"/>
+    <property name="sun.os.patch.level" value="unknown"/>
+    <property name="java.vm.specification.name" value="Java Virtual Machine Specification"/>
+    <property name="user.dir" value="/Users/runbld/elastic/src/runbld/test/repo/java/some-errors"/>
+    <property name="java.runtime.version" value="1.8.0_131-b11"/>
+    <property name="java.awt.graphicsenv" value="sun.awt.CGraphicsEnvironment"/>
+    <property name="java.endorsed.dirs" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/endorsed"/>
+    <property name="os.arch" value="x86_64"/>
+    <property name="java.io.tmpdir" value="/var/folders/02/y03mldq14rq7kt1nfqm73c140000gn/T/"/>
+    <property name="line.separator" value="
+"/>
+    <property name="java.vm.specification.vendor" value="Oracle Corporation"/>
+    <property name="os.name" value="Mac OS X"/>
+    <property name="classworlds.conf" value="/usr/local/Cellar/maven/3.5.0/libexec/bin/m2.conf"/>
+    <property name="sun.jnu.encoding" value="UTF-8"/>
+    <property name="java.library.path" value="/Users/runbld/Library/Java/Extensions:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java:."/>
+    <property name="maven.conf" value="/usr/local/Cellar/maven/3.5.0/libexec/conf"/>
+    <property name="java.specification.name" value="Java Platform API Specification"/>
+    <property name="java.class.version" value="52.0"/>
+    <property name="sun.management.compiler" value="HotSpot 64-Bit Tiered Compilers"/>
+    <property name="os.version" value="10.13.6"/>
+    <property name="library.jansi.path" value="/usr/local/Cellar/maven/3.5.0/libexec/lib/jansi-native/osx64"/>
+    <property name="http.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="user.home" value="/Users/runbld"/>
+    <property name="user.timezone" value="America/New_York"/>
+    <property name="java.awt.printerjob" value="sun.lwawt.macosx.CPrinterJob"/>
+    <property name="java.specification.version" value="1.8"/>
+    <property name="file.encoding" value="UTF-8"/>
+    <property name="user.name" value="runbld"/>
+    <property name="java.class.path" value="/usr/local/Cellar/maven/3.5.0/libexec/boot/plexus-classworlds-2.5.2.jar"/>
+    <property name="java.vm.specification.version" value="1.8"/>
+    <property name="sun.arch.data.model" value="64"/>
+    <property name="java.home" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre"/>
+    <property name="sun.java.command" value="org.codehaus.plexus.classworlds.launcher.Launcher test"/>
+    <property name="java.specification.vendor" value="Oracle Corporation"/>
+    <property name="user.language" value="en"/>
+    <property name="awt.toolkit" value="sun.lwawt.macosx.LWCToolkit"/>
+    <property name="java.vm.info" value="mixed mode"/>
+    <property name="java.version" value="1.8.0_131"/>
+    <property name="java.ext.dirs" value="/Users/runbld/Library/Java/Extensions:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/ext:/Library/Java/Extensions:/Network/Library/Java/Extensions:/System/Library/Java/Extensions:/usr/lib/java"/>
+    <property name="sun.boot.class.path" value="/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/resources.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/rt.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/sunrsasign.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jsse.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jce.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/charsets.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/lib/jfr.jar:/Library/Java/JavaVirtualMachines/jdk1.8.0_131.jdk/Contents/Home/jre/classes"/>
+    <property name="java.vendor" value="Oracle Corporation"/>
+    <property name="maven.home" value="/usr/local/Cellar/maven/3.5.0/libexec"/>
+    <property name="file.separator" value="/"/>
+    <property name="java.vendor.url.bug" value="http://bugreport.sun.com/bugreport/"/>
+    <property name="sun.cpu.endian" value="little"/>
+    <property name="sun.io.unicode.encoding" value="UnicodeBig"/>
+    <property name="socksNonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="ftp.nonProxyHosts" value="local|*.local|169.254/16|*.169.254/16"/>
+    <property name="sun.cpu.isalist" value=""/>
+  </properties>
+  <testcase classname="com.example.AppTest" name="testError" time="0.014">
+    <error message="/some/bad/file" type="java.nio.file.NoSuchFileException">java.nio.file.NoSuchFileException: /some/bad/file
+	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
+	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
+	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
+	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
+	at java.nio.file.Files.newByteChannel(Files.java:361)
+	at java.nio.file.Files.newByteChannel(Files.java:407)
+	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384)
+	at java.nio.file.Files.newInputStream(Files.java:152)
+	at java.nio.file.Files.newBufferedReader(Files.java:2784)
+	at java.nio.file.Files.newBufferedReader(Files.java:2816)
+	at com.example.AppTest.testError(AppTest.java:42)
+</error>
+  </testcase>
+  <testcase classname="com.example.AppTest" name="testGood" time="0.001"/>
+  <testcase classname="com.example.AppTest" name="testBad" time="0">
+    <failure type="junit.framework.AssertionFailedError">junit.framework.AssertionFailedError
+	at junit.framework.Assert.fail(Assert.java:47)
+	at junit.framework.Assert.assertTrue(Assert.java:20)
+	at junit.framework.Assert.assertTrue(Assert.java:27)
+	at com.example.AppTest.testBad(AppTest.java:37)
+</failure>
+  </testcase>
+</testsuite>

--- a/test/repo/python/no-errors/TEST-no-errors.xml
+++ b/test/repo/python/no-errors/TEST-no-errors.xml
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="nosetests" tests="1" errors="0" failures="0" skip="0"><testcase classname="test.HelloWorld" name="test_hello" time="0.000"></testcase></testsuite>

--- a/test/repo/python/some-errors/TEST-some-errors.xml
+++ b/test/repo/python/some-errors/TEST-some-errors.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?><testsuite name="nosetests" tests="2" errors="1" failures="1" skip="0"><testcase classname="test.HelloWorld" name="test_error" time="0.000"><error type="exceptions.Exception" message="Goodbye, world!"><![CDATA[Traceback (most recent call last):
+  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 331, in run
+    testMethod()
+  File "/Users/runbld/elastic/src/runbld/test/repo/python/some-errors/tests/test.py", line 8, in test_error
+    raise Exception('Goodbye, world!')
+Exception: Goodbye, world!
+]]></error></testcase><testcase classname="test.HelloWorld" name="test_hello" time="0.000"><failure type="exceptions.AssertionError" message="False is not true"><![CDATA[Traceback (most recent call last):
+  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 331, in run
+    testMethod()
+  File "/Users/runbld/elastic/src/runbld/test/repo/python/some-errors/tests/test.py", line 5, in test_hello
+    self.assert_('Hello, world!' != 'Hello, world!')
+  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/unittest/case.py", line 424, in assertTrue
+    raise self.failureException(msg)
+AssertionError: False is not true
+]]></failure></testcase></testsuite>


### PR DESCRIPTION
This PR adds the xml files that are produced by mvn/go/python.  The intent here is to reduce the amount of pain that someone needs to go through just to run the tests.  I.e., don't need to install go, python, nose, etc.