### PR TITLE
Dont wait forever

### DIFF
--- a/changelog.org
+++ b/changelog.org
@@ -1,4 +1,8 @@
 * runbld changes
+** 1.5.18
+   - Add timeout around reading from stdout/stderr.  Sometimes
+     subprocesses can spawn other processes and somewhere along the
+     line never end up closing the streams.
 ** 1.5.17
    - added more debug logging
    - fail fast when encountering a 404 during ec2-meta

--- a/src/clj/runbld/process.clj
+++ b/src/clj/runbld/process.clj
@@ -239,7 +239,7 @@
         listeners [file-ch es-ch stdout-ch stderr-ch]
         result (exec program args scriptfile cwd
                      env listeners log-extra timeout)
-        ;; The process has exited, flush the channels
+        ;; The process has exited, wait for these channels to close
         _ (doall (map <!!
                       [file-process es-process]))
         ;; stdout and stderr channels might hang on bad input.

--- a/src/clj/runbld/process.clj
+++ b/src/clj/runbld/process.clj
@@ -8,15 +8,13 @@
    [runbld.io :as io]
    [runbld.schema :refer :all]
    [runbld.store :as store]
-   [runbld.util.data :as data]
    [runbld.util.date :as date]
    [runbld.util.debug :as debug]
    [schema.core :as s])
   (:import
    (clojure.core.async.impl.channels ManyToManyChannel)
-   (clojure.lang Atom Ref)
+   (clojure.lang Ref)
    (java.io File InputStream)
-   (java.util UUID)
    (java.util.concurrent TimeUnit)))
 
 (s/defn inc-ordinals


### PR DESCRIPTION
This took a bit to track down but we finally managed to determine that the process was exiting correctly but then hanging when trying to read the final bits from the stdout/stderr async channels.  

The runbld issue was that the async thread reading from the stream was waiting indefinitely for new input [here](https://github.com/elastic/runbld/blob/a562b882f140445d6b2d8404871a3f33a170c6d7/src/clj/runbld/process.clj#L56) and never proceeding to the `close!` call.  That caused `<!!` to hang, blocking the main thread.

This PR adds a timeout to those reads.