### PR TITLE
Report gen logging

### DIFF
--- a/src/clj/runbld/schema.clj
+++ b/src/clj/runbld/schema.clj
@@ -263,7 +263,7 @@
    :test       s/Str
    :stacktrace s/Str
    :summary    s/Str
-   :type       s/Str
+   (s/optional-key :type)    s/Str
    (s/optional-key :message) s/Str})
 
 (def TestSummary

--- a/src/clj/runbld/tests/junit.clj
+++ b/src/clj/runbld/tests/junit.clj
@@ -88,9 +88,10 @@
 
 (defn find-failures [dir filename-format]
   ;; find the xml files
-  (debug/log "Searching for junit test output files")
+  (rio/log "Searching for junit test output files with the pattern:"
+           filename-format "in:" (rio/abspath dir))
   (let [failures (rio/find-files dir (re-pattern filename-format))
-        _ (debug/log "Found" (count failures) "test failures")
+        _ (rio/log "Found" (count failures) "test output files")
         reports (for [failure failures
                       :let [xml (try
                                   (debug/log "Parsing" (rio/abspath failure))

--- a/src/clj/runbld/tests/junit.clj
+++ b/src/clj/runbld/tests/junit.clj
@@ -104,16 +104,22 @@
                                     nil))]
                       :when xml]
                   (do
-                    (debug/log "Looking for testsuite node")
+                    (rio/log "Looking for testsuite node in"
+                             (.getName (io/file failure)))
                     (if-let [testsuite (x/select xml [[(x/tag= :testsuite)]])]
                       (merge-default (make-failure-report testsuite))
-                      (debug/log "none found"))))]
+                      (rio/log "No testsuite node found."))))]
     (debug/log "Made" (count reports) "reports")
     (debug/log "Combining reports")
-    (reduce combine-failure-reports
-            {:errors 0
-             :failures 0
-             :tests 0
-             :skipped 0
-             :failed-testcases []}
-            reports)))
+    (let [summary (reduce combine-failure-reports
+                          {:errors 0
+                           :failures 0
+                           :tests 0
+                           :skipped 0
+                           :failed-testcases []}
+                          reports)]
+      (rio/log "Errors:" (:errors summary)
+               "Failures:" (:failures summary)
+               "Tests:" (:tests summary)
+               "Skipped:" (:skipped summary))
+      summary)))

--- a/test/repo/misc/ABCD-missing-type.xml
+++ b/test/repo/misc/ABCD-missing-type.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites>
+  <testsuite name="Filter_My_Cases_All_Cases" timestamp="2018-09-04T02:21:09" time="10.424" tests="1" failures="0" errors="1" skipped="0">
+    <properties>
+      <property name="specId" value="0asdfasdfasdf"/>
+      <property name="suiteName" value="Filter My Cases/All Cases"/>
+      <property name="capabilities" value="chrome"/>
+      <property name="file" value="./test/specs/site/filterCases.js"/>
+    </properties>
+    <testcase classname="chrome.Filter_My_Cases_All_Cases" name="before_all_hook" time="196.721">
+      <error message="element (&quot;#sfdc_username_container&quot;) still not visible after 10000ms"/>
+      <system-err>
+        <![CDATA[
+Error: element ("#username_container") still not visible after 10000ms
+    at elements("#username_container") - isVisible.js:54:17
+    at isVisible("#username_container") - waitForVisible.js:73:22
+]]>
+      </system-err>
+    </testcase>
+  </testsuite>
+</testsuites>

--- a/test/runbld/tests_test.clj
+++ b/test/runbld/tests_test.clj
@@ -9,7 +9,9 @@
 
 (use-fixtures :once schema.test/validate-schemas)
 
-(use-fixtures :each ts/reset-debug-log-fixture)
+(use-fixtures :each
+  (ts/redirect-logging-fixture)
+  ts/reset-debug-log-fixture)
 
 (def filename-pattern "/TEST-.*\\.xml$")
 


### PR DESCRIPTION
Log the pattern used and how many files are found when rounding up junit output files.  This is in support of debugging missing data.